### PR TITLE
Allow to return internal events in actor

### DIFF
--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -12,7 +12,7 @@ import vivid.money.elmslie.core.config.ElmslieConfig
 class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
     initialState: State,
     private val reducer: StateReducer<Event, State, Effect, Command>,
-    private val actor: Actor<Command, Event>
+    private val actor: Actor<Command, out Event>
 ) : Store<Event, Effect, State> {
 
     private val logger = ElmslieConfig.logger

--- a/elmslie-rxjava-2/src/main/java/vivid/money/elmslie/core/ElmStoreCompat.kt
+++ b/elmslie-rxjava-2/src/main/java/vivid/money/elmslie/core/ElmStoreCompat.kt
@@ -1,5 +1,6 @@
 package vivid.money.elmslie.core
 
+import vivid.money.elmslie.core.store.Actor
 import vivid.money.elmslie.core.store.ElmStore
 import vivid.money.elmslie.core.store.StateReducer
 import vivid.money.elmslie.core.store.Store
@@ -7,9 +8,12 @@ import vivid.money.elmslie.core.store.Store
 class ElmStoreCompat<Event : Any, State : Any, Effect : Any, Command : Any>(
     initialState: State,
     reducer: StateReducer<Event, State, Effect, Command>,
-    actor: ActorCompat<Command, Event>
+    actor: ActorCompat<Command, out Event>
 ) : Store<Event, Effect, State> by ElmStore(
     initialState = initialState,
     reducer = reducer,
-    actor = { actor.execute(it).toV3() }
+    actor = actor.toActor()
 )
+
+private fun <Command : Any, Event : Any> ActorCompat<Command, Event>
+        .toActor() = Actor<Command, Event> { execute(it).toV3() }

--- a/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/elm/Store.kt
+++ b/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/elm/Store.kt
@@ -8,9 +8,9 @@ import vivid.money.elmslie.samples.android.loader.elm.Event.Internal
 import vivid.money.elmslie.samples.android.loader.elm.Event.Ui
 import vivid.money.elmslie.samples.android.loader.repository.ValueRepository
 
-class Actor : ActorCompat<Command, Event> {
+class Actor : ActorCompat<Command, Internal> {
 
-    override fun execute(command: Command): Observable<Event> = when (command) {
+    override fun execute(command: Command): Observable<Internal> = when (command) {
         is Command.LoadNewValue -> ValueRepository.getValue()
             .mapEvents(Internal::ValueLoaded, Internal.ErrorLoadingValue)
     }


### PR DESCRIPTION
Now Actor.execute has the return type Observable<Event>, but in ui implementation it would be more convenient to limit it to Observable<Event.Internal>
@EdKornev, maybe we should add this to the code generator plugin as well?