### PR TITLE
Store view model persisting

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
@@ -3,7 +3,8 @@ package vivid.money.elmslie.android.base
 import androidx.appcompat.app.AppCompatActivity
 import vivid.money.elmslie.android.screen.ElmDelegate
 import vivid.money.elmslie.android.screen.ElmScreen
-import vivid.money.elmslie.android.util.fastLazy
+import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
+import vivid.money.elmslie.android.storeholder.StoreHolder
 
 abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     AppCompatActivity(), ElmDelegate<Event, Effect, State> {
@@ -11,5 +12,8 @@ abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     @Suppress("LeakingThis")
     private val elm = ElmScreen(this, lifecycle) { this }
 
-    protected val store by fastLazy { elm.store }
+    protected val store
+        get() = storeHolder.store
+
+    override val storeHolder: StoreHolder<Event, Effect, State> = LifecycleAwareStoreHolder(lifecycle, ::createStore)
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
@@ -3,12 +3,16 @@ package vivid.money.elmslie.android.base
 import androidx.fragment.app.Fragment
 import vivid.money.elmslie.android.screen.ElmDelegate
 import vivid.money.elmslie.android.screen.ElmScreen
-import vivid.money.elmslie.android.util.fastLazy
+import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
+import vivid.money.elmslie.android.storeholder.StoreHolder
 
 abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment(), ElmDelegate<Event, Effect, State> {
 
     @Suppress("LeakingThis")
     private val elm = ElmScreen(this, lifecycle) { requireActivity() }
 
-    protected val store by fastLazy { elm.store }
+    protected val store
+        get() = storeHolder.store
+
+    override val storeHolder: StoreHolder<Event, Effect, State> = LifecycleAwareStoreHolder(lifecycle, ::createStore)
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
@@ -1,5 +1,6 @@
 package vivid.money.elmslie.android.screen
 
+import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
 /**
@@ -8,6 +9,8 @@ import vivid.money.elmslie.core.store.Store
 interface ElmDelegate<Event : Any, Effect : Any, State : Any> {
 
     val initEvent: Event
+    val storeHolder: StoreHolder<Event, Effect, State>
+
     fun createStore(): Store<Event, Effect, State>
     fun render(state: State)
     fun handleEffect(effect: Effect): Unit? = Unit

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
@@ -1,0 +1,26 @@
+package vivid.money.elmslie.android.storeholder
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import vivid.money.elmslie.android.util.fastLazy
+import vivid.money.elmslie.core.store.Store
+
+class LifecycleAwareStoreHolder<Event : Any, Effect : Any, State : Any>(
+    lifecycle: Lifecycle,
+    storeProvider: () -> Store<Event, Effect, State>,
+) : StoreHolder<Event, Effect, State> {
+
+    override val store by fastLazy { storeProvider() }
+
+    private val lifecycleObserver: LifecycleObserver = object : LifecycleObserver {
+        @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        fun onDestroy() {
+            store.stop()
+        }
+    }
+
+    init {
+        lifecycle.addObserver(lifecycleObserver)
+    }
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
@@ -11,7 +11,7 @@ class LifecycleAwareStoreHolder<Event : Any, Effect : Any, State : Any>(
     storeProvider: () -> Store<Event, Effect, State>,
 ) : StoreHolder<Event, Effect, State> {
 
-    override val store by fastLazy { storeProvider() }
+    override val store by fastLazy { storeProvider().start() }
 
     private val lifecycleObserver: LifecycleObserver = object : LifecycleObserver {
         @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
@@ -1,0 +1,14 @@
+package vivid.money.elmslie.android.storeholder
+
+import vivid.money.elmslie.core.store.Store
+
+/**
+ * Implementation of this interface should:
+ *  1. call Store::start during store creation
+ *  2. guarantee invariance of store while the view exists
+ *  3. call Store::stop when store be ready to gc
+ **/
+interface StoreHolder<Event : Any, Effect : Any, State : Any> {
+
+    val store: Store<Event, Effect, State>
+}

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -37,6 +37,9 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
     override fun accept(event: Event) = eventsInternal.onNext(event)
 
     override fun start(): Store<Event, Effect, State> {
+        if (isStarted) {
+            logger.fatal("Store is already started. Usually, it happened inside StoreHolder.")
+        }
         effectsBuffer.init().bind()
 
         eventsInternal

--- a/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/elm/Store.kt
+++ b/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/elm/Store.kt
@@ -45,4 +45,4 @@ fun storeFactory() = ElmStoreCompat(
     initialState = State(),
     reducer = Reducer(),
     actor = Actor()
-).start()
+)

--- a/elmslie-samples/kotlin-calculator/src/main/java/vivid/money/elmslie/samples/calculator/Store.kt
+++ b/elmslie-samples/kotlin-calculator/src/main/java/vivid/money/elmslie/samples/calculator/Store.kt
@@ -42,4 +42,4 @@ fun createStore() = ElmStore(
     initialState = State(),
     reducer = Reducer,
     actor = Actor
-).start()
+)

--- a/elmslie-store-persisting/build.gradle
+++ b/elmslie-store-persisting/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id("com.android.library")
+    id("kotlin-android")
+}
+
+dependencies {
+    implementation(project(":elmslie-core"))
+    implementation(project(":elmslie-android"))
+
+    implementation(deps.android.appcompat)
+    implementation(deps.android.lifecycleViewModelSavedState)
+}
+
+apply from: "../gradle/junit-5.gradle"
+apply from: "../gradle/android-library.gradle"
+apply from: "../gradle/android-publishing.gradle"

--- a/elmslie-store-persisting/src/main/AndroidManifest.xml
+++ b/elmslie-store-persisting/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="vivid.money.elmslie.storepersisting" />

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
@@ -7,7 +7,7 @@ internal class ClearableStoreHolder<Event : Any, Effect : Any, State : Any>(
     storeProvider: () -> Store<Event, Effect, State>,
 ) : StoreHolder<Event, Effect, State> {
 
-    override val store: Store<Event, Effect, State> = storeProvider()
+    override val store: Store<Event, Effect, State> = storeProvider().start()
 
     fun clear() {
         store.stop()

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
@@ -1,0 +1,15 @@
+package vivid.money.elmslie.storepersisting
+
+import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.store.Store
+
+internal class ClearableStoreHolder<Event : Any, Effect : Any, State : Any>(
+    storeProvider: () -> Store<Event, Effect, State>,
+) : StoreHolder<Event, Effect, State> {
+
+    override val store: Store<Event, Effect, State> = storeProvider()
+
+    fun clear() {
+        store.stop()
+    }
+}

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/RetainedExtentions.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/RetainedExtentions.kt
@@ -1,0 +1,74 @@
+package vivid.money.elmslie.storepersisting
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
+
+internal inline fun <reified R : ClearableStoreHolder<*, *, *>> ComponentActivity.retain(
+    key: String = R::class.java.name,
+    noinline getDefaultArgs: () -> Bundle = { intent.extras ?: Bundle() },
+    noinline createRetainedStoreHolder: (SavedStateHandle) -> R,
+): Lazy<R> {
+    val getActivity: () -> ComponentActivity = { this }
+    return createRetainedStoreHolderLazy(
+        key = key,
+        getViewModelStoreOwner = getActivity,
+        getSavedStateRegistryOwner = getActivity,
+        getDefaultArgs = getDefaultArgs,
+        createStoreHolder = createRetainedStoreHolder
+    )
+}
+
+internal inline fun <reified R : ClearableStoreHolder<*, *, *>> Fragment.retain(
+    key: String = R::class.java.name,
+    noinline getDefaultArgs: () -> Bundle = { arguments ?: Bundle() },
+    noinline createRetainedStoreHolder: (SavedStateHandle) -> R,
+): Lazy<R> {
+    val getFragment: () -> Fragment = { this }
+    return createRetainedStoreHolderLazy(
+        key = key,
+        getViewModelStoreOwner = getFragment,
+        getSavedStateRegistryOwner = getFragment,
+        getDefaultArgs = getDefaultArgs,
+        createStoreHolder = createRetainedStoreHolder
+    )
+}
+
+internal inline fun <reified R : ClearableStoreHolder<*, *, *>> Fragment.retainInActivity(
+    key: String = R::class.java.name,
+    noinline getDefaultArgs: () -> Bundle = { activity?.intent?.extras ?: Bundle() },
+    noinline createRetainedStoreHolder: (SavedStateHandle) -> R,
+): Lazy<R> = createRetainedStoreHolderLazy(
+    key = key,
+    getViewModelStoreOwner = ::requireActivity,
+    getSavedStateRegistryOwner = ::requireActivity,
+    getDefaultArgs = getDefaultArgs,
+    createStoreHolder = createRetainedStoreHolder
+)
+
+internal inline fun <reified R : ClearableStoreHolder<*, *, *>> Fragment.retainInParent(
+    key: String = R::class.java.name,
+    noinline getDefaultArgs: () -> Bundle = ::parentDefaultArgs,
+    noinline createRetainedStoreHolder: (SavedStateHandle) -> R,
+): Lazy<R> = createRetainedStoreHolderLazy(
+    key = key,
+    getViewModelStoreOwner = ::parentViewModelStoreOwner,
+    getSavedStateRegistryOwner = ::parentSavedStateRegistryOwner,
+    getDefaultArgs = getDefaultArgs,
+    createStoreHolder = createRetainedStoreHolder
+)
+
+@PublishedApi
+internal val Fragment.parentDefaultArgs: Bundle
+    get() = parentFragment?.arguments ?: activity?.intent?.extras ?: Bundle()
+
+@PublishedApi
+internal val Fragment.parentViewModelStoreOwner: ViewModelStoreOwner
+    get() = parentFragment ?: requireActivity()
+
+@PublishedApi
+internal val Fragment.parentSavedStateRegistryOwner: SavedStateRegistryOwner
+    get() = parentFragment ?: requireActivity()

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/RetainedStoreHolder.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/RetainedStoreHolder.kt
@@ -1,0 +1,61 @@
+package vivid.money.elmslie.storepersisting
+
+import android.os.Bundle
+import androidx.annotation.MainThread
+import androidx.lifecycle.*
+import androidx.savedstate.SavedStateRegistryOwner
+
+@MainThread
+fun <R : ClearableStoreHolder<*, *, *>> createRetainedStoreHolderLazy(
+    key: String,
+    getViewModelStoreOwner: () -> ViewModelStoreOwner,
+    getSavedStateRegistryOwner: () -> SavedStateRegistryOwner,
+    getDefaultArgs: () -> Bundle,
+    createStoreHolder: (SavedStateHandle) -> R,
+): Lazy<R> = lazy(LazyThreadSafetyMode.NONE) {
+    createRetainedStoreHolder(
+        key = key,
+        viewModelStoreOwner = getViewModelStoreOwner(),
+        savedStateRegistryOwner = getSavedStateRegistryOwner(),
+        defaultArgs = getDefaultArgs(),
+        createStoreHolder = createStoreHolder
+    )
+}
+
+private fun <R : ClearableStoreHolder<*, *, *>> createRetainedStoreHolder(
+    key: String,
+    viewModelStoreOwner: ViewModelStoreOwner,
+    savedStateRegistryOwner: SavedStateRegistryOwner,
+    defaultArgs: Bundle,
+    createStoreHolder: (SavedStateHandle) -> R,
+): R {
+    val factory = RetainedViewModelFactory(savedStateRegistryOwner, defaultArgs, createStoreHolder)
+    val provider = ViewModelProvider(viewModelStoreOwner, factory)
+
+    @Suppress("UNCHECKED_CAST")
+    return provider.get(key, RetainedViewModel::class.java).retainedStoreHolder as R
+}
+
+private class RetainedViewModel(
+    savedStateHandle: SavedStateHandle,
+    createStoreHolder: (SavedStateHandle) -> ClearableStoreHolder<*, *, *>,
+) : ViewModel() {
+
+    val retainedStoreHolder = createStoreHolder(savedStateHandle)
+
+    override fun onCleared() {
+        retainedStoreHolder.clear()
+    }
+}
+
+private class RetainedViewModelFactory(
+    owner: SavedStateRegistryOwner,
+    defaultArgs: Bundle,
+    private val createStoreHolder: (SavedStateHandle) -> ClearableStoreHolder<*, *, *>,
+) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+
+    override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
+        @Suppress("UNCHECKED_CAST")
+        return RetainedViewModel(handle, createStoreHolder) as T
+    }
+}

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/StoreHolders.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/StoreHolders.kt
@@ -1,0 +1,26 @@
+package vivid.money.elmslie.storepersisting
+
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.store.Store
+
+fun <Event : Any, Effect : Any, State : Any> ComponentActivity.retainStoreHolder(
+    storeName: String = "${this::class.java.name}Store",
+    storeProvider: () -> Store<Event, Effect, State>,
+): Lazy<StoreHolder<Event, Effect, State>> = this.retain(storeName) { ClearableStoreHolder(storeProvider) }
+
+fun <Event : Any, Effect : Any, State : Any> Fragment.retainStoreHolder(
+    storeName: String = "${this::class.java.name}Store",
+    storeProvider: () -> Store<Event, Effect, State>,
+): Lazy<StoreHolder<Event, Effect, State>> = this.retain(storeName) { ClearableStoreHolder(storeProvider) }
+
+fun <Event : Any, Effect : Any, State : Any> Fragment.retainInParentStoreHolder(
+    storeName: String = "${this::class.java.name}Store",
+    storeProvider: () -> Store<Event, Effect, State>,
+): Lazy<StoreHolder<Event, Effect, State>> = this.retainInParent(storeName) { ClearableStoreHolder(storeProvider) }
+
+fun <Event : Any, Effect : Any, State : Any> Fragment.retainInActivityStoreHolder(
+    storeName: String = "${this::class.java.name}Store",
+    storeProvider: () -> Store<Event, Effect, State>,
+): Lazy<StoreHolder<Event, Effect, State>> = this.retainInActivity(storeName) { ClearableStoreHolder(storeProvider) }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -1,18 +1,19 @@
 ext.versions = [
-        kotlin       : "1.5.0",
-        detekt       : "1.16.0",
-        androidPlugin: "4.2.0",
-        appcompat    : "1.2.0",
-        material     : "1.3.0",
-        appStartup   : "1.0.0",
-        rxJava2      : "2.2.21",
-        rxJava3Bridge: "3.0.0",
-        rxJava3      : "3.0.11",
-        rxAndroid    : "3.0.0",
-        jUnit5       : "5.7.1",
-        kotest       : "4.4.3",
-        freemarker   : "2.3.31",
-        intellij     : "0.6.5",
+        kotlin          : "1.5.0",
+        detekt          : "1.16.0",
+        androidPlugin   : "4.2.0",
+        appcompat       : "1.2.0",
+        material        : "1.3.0",
+        lifecycleVersion: "2.3.1",
+        appStartup      : "1.0.0",
+        rxJava2         : "2.2.21",
+        rxJava3Bridge   : "3.0.0",
+        rxJava3         : "3.0.11",
+        rxAndroid       : "3.0.0",
+        jUnit5          : "5.7.1",
+        kotest          : "4.4.3",
+        freemarker      : "2.3.31",
+        intellij        : "0.6.5",
 ]
 
 ext.deps = [
@@ -23,9 +24,11 @@ ext.deps = [
                 detektPlugin  : "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$versions.detekt"
         ],
         android: [
-                appcompat : "androidx.appcompat:appcompat:$versions.appcompat",
-                material  : "com.google.android.material:material:$versions.material",
-                appStartup: "androidx.startup:startup-runtime:$versions.appStartup",
+                appcompat                   : "androidx.appcompat:appcompat:$versions.appcompat",
+                lifecycleViewmodel          : "androidx.lifecycle:lifecycle-viewmodel:$versions.lifecycleVersion",
+                lifecycleViewModelSavedState: "androidx.lifecycle:lifecycle-viewmodel-savedstate:$versions.lifecycleVersion",
+                material                    : "com.google.android.material:material:$versions.material",
+                appStartup                  : "androidx.startup:startup-runtime:$versions.appStartup",
         ],
         rx     : [
                 rxJava2      : "io.reactivex.rxjava2:rxjava:$versions.rxJava2",

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,5 +10,6 @@ include ':sample-android-loader'
 project(":sample-android-loader").projectDir = file("elmslie-samples/android-loader")
 include ':elmslie-plugin'
 project(":elmslie-plugin").projectDir = file("elmslie-plugin")
+include ':elmslie-store-persisting'
 
 rootProject.name = "Elmslie"


### PR DESCRIPTION
There is one additional module `elmslie-store-persisting` to allow to save store inside ViewModel and reused it later (exactly the same approach that we used inside the main project). I'm not sure about naming, will be glad to advise.

Also, this PR contains one breaking change in a separate commit - I moved Store::start from the factory to StoreHolder (it makes more sense since stop is StoreHolder responsibility).