### PR TITLE
Migrate from jcenter to maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     apply from: 'gradle/dependencies.gradle'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://plugins.gradle.org/m2/"
         }


### PR DESCRIPTION
Jcenter is dicontinued: https://developer.android.com/studio/build/jcenter-migration
There were no specific jcenter dependencies so the migration is very simple 