### PR TITLE
Fix plugin for code generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Samples are available [here](https://github.com/vivid-money/elmslie/tree/main/el
 - Pure java notes: [link](https://github.com/vivid-money/elmslie/tree/main/elmslie-samples/java-notes)
 - Paging with compose: [link](https://github.com/vivid-money/elmslie/tree/main/elmslie-samples/compose-paging)
 
+## Code generation plugin for Android Studio
+More info in the [wiki article](https://github.com/vivid-money/elmslie/wiki)
+
 ## Download
 Library is distributed through JitPack
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Samples are available [here](https://github.com/vivid-money/elmslie/tree/main/el
 - Paging with compose: [link](https://github.com/vivid-money/elmslie/tree/main/elmslie-samples/compose-paging)
 
 ## Code generation plugin for Android Studio
+Plugin is available at the [Jetbrains plugin repository](https://plugins.jetbrains.com/plugin/17176-elmslie-generator/versions/stable/125661)
 More info in the [wiki article](https://github.com/vivid-money/elmslie/wiki)
 
 ## Download

--- a/elmslie-plugin/build.gradle
+++ b/elmslie-plugin/build.gradle
@@ -12,16 +12,16 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2018.3'
-    updateSinceUntilBuild false
+    version = '2018.3'
+    updateSinceUntilBuild = false
     plugins = ['android', 'Kotlin']
 
-//    alternativeIdePath 'C://Program Files/Android/Android Studio' // for Windows
-    alternativeIdePath '/Applications/Android Studio.app' // for MacOS
 }
+// runIde.ideDir = layout.projectDirectory.dir('C://Program Files/Android/Android Studio') // for Windows
+runIde.ideDir = layout.projectDirectory.dir('/Applications/Android Studio.app') // for MacOS
 
 patchPluginXml {
-    changeNotes """
+    changeNotes = """
       Can create simple presentation layer<br>
       """
 }

--- a/elmslie-plugin/src/main/kotlin/vivid/money/elmslie/plugin/presentation/PresentationLayerAction.kt
+++ b/elmslie-plugin/src/main/kotlin/vivid/money/elmslie/plugin/presentation/PresentationLayerAction.kt
@@ -23,7 +23,7 @@ class PresentationLayerAction : AnAction() {
             val dialog = CreatePresentationLayerDialog { model ->
                 project.runWriteAction {
                     try {
-                        project.getComponent(PresentationLayerController::class.java).generate(model, target)
+                        PresentationLayerController(project).generate(model, target)
                     } catch (error: Exception) {
                         val errorDialog = DialogBuilder()
                         errorDialog.setErrorText(ERROR_SOMETHING_WRONG + error.message)

--- a/elmslie-plugin/src/main/kotlin/vivid/money/elmslie/plugin/presentation/views/CreatePresentationLayerDialog.kt
+++ b/elmslie-plugin/src/main/kotlin/vivid/money/elmslie/plugin/presentation/views/CreatePresentationLayerDialog.kt
@@ -15,7 +15,7 @@ class CreatePresentationLayerDialog(
 
     init {
         super.init()
-        title = "Create presentation layer"
+        title = "Generate store"
     }
 
     override fun createCenterPanel(): JComponent? {

--- a/elmslie-plugin/src/main/resources/META-INF/plugin.xml
+++ b/elmslie-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,11 +1,23 @@
 <idea-plugin>
-    <id>vivid.money.elmslie.plugin</id>
+    <id>vivid.money.elmslie.plugin.codegenerator</id>
     <name>ELMSLIE GENERATOR</name>
     <vendor email="support@vivid.money" url="https://vivid.money">Vivid money</vendor>
+    <idea-version since-build="193" />
 
     <description><![CDATA[
     Plugin helps to generate presentation layer.
+    <br />
     Elmslie architecture for android: https://github.com/vivid-money/elmslie
+    <br />
+    How to use:
+    <br />
+    <ul>
+        <li>Click on the package with your source code where you want the code to be generated (Inside the project view)</li>
+        <li>Go to Tools/Elmslie/Generate store</li>
+        <li>Enter you base class name (i.e. for SomeFeatureReducer enter just "SomeFeature")</li>
+        <li>(Optional) Select the checkbox if you want to use the reducer dsl for ui features</li>
+        <li>Click OK</li>
+    </ul>
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html
@@ -15,21 +27,14 @@
     <depends>org.jetbrains.android</depends>
 
     <actions>
-        <group id="vivid.money.elmslie.plugin.group" text="Elmslie" description="Create presentation layer">
+        <group id="vivid.money.elmslie.plugin.group" text="Elmslie" description="Generate store" popup="true">
             <separator/>
             <action id="vivid.money.elmslie.plugin.presentation.PresentationLayerAction"
                     class="vivid.money.elmslie.plugin.presentation.PresentationLayerAction"
-                    text="Generate Presentation Layer">
+                    text="Generate Presentation Layer"
+                    description="Generate classes for presentation layer">
             </action>
-            <add-to-group group-id="NewGroup" anchor="last"/>
+            <add-to-group group-id="ToolsMenu" anchor="after" relative-to-action="org.intellij.sdk.action.PopupDialogAction"/>
         </group>
     </actions>
-
-    <project-components>
-        <component>
-            <implementation-class>
-                vivid.money.elmslie.plugin.presentation.controller.PresentationLayerController
-            </implementation-class>
-        </component>
-    </project-components>
 </idea-plugin>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -7,7 +7,7 @@ ext.deps = [
         gradle : [
                 androidPlugin : "com.android.tools.build:gradle:7.0.0",
                 kotlinPlugin  : "org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.21",
-                intellijPlugin: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:0.6.5",
+                intellijPlugin: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.0",
                 detektPlugin  : "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.1",
                 releasesHub   : "com.dipien:releases-hub-gradle-plugin:2.0.2",
         ],


### PR DESCRIPTION
Code generation plugin didn't work correctly, so this mr:
- Updates intellij plugin to 1.0
- Fixes the plugin
- Adds info about it to the readme

Also, there's a new wiki page about it https://github.com/vivid-money/elmslie/wiki/Code-generation-plugin-for-Android-Studio
Plugin is now available at https://plugins.jetbrains.com/plugin/17176-elmslie-generator/versions/stable/125661