### PR TITLE
Fix double start reporting issue

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/logger/strategy/Crash.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/logger/strategy/Crash.kt
@@ -12,6 +12,10 @@ object Crash : LogStrategy {
     private val errorHandler = Handler(Looper.getMainLooper()) { throw it.obj as Throwable }
 
     override fun invoke(severity: LogSeverity, message: String, error: Throwable?) {
-        errorHandler.sendMessage(Message().also { it.obj = error ?: return })
+        errorHandler.sendMessage(
+            Message().apply {
+                obj = error ?: Exception(message)
+            }
+        )
     }
 }


### PR DESCRIPTION
It was possible to call start twice and there was no report about this because we set `isStarted = true` at the end of the start method.