### PR TITLE
Fix parent class StoreHodler initialisation inside ElmActivity and ElmFragment

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
@@ -5,6 +5,7 @@ import vivid.money.elmslie.android.screen.ElmDelegate
 import vivid.money.elmslie.android.screen.ElmScreen
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.android.util.fastLazy
 
 abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     AppCompatActivity(), ElmDelegate<Event, Effect, State> {
@@ -15,5 +16,7 @@ abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     protected val store
         get() = storeHolder.store
 
-    override val storeHolder: StoreHolder<Event, Effect, State> = LifecycleAwareStoreHolder(lifecycle, ::createStore)
+    override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
+        LifecycleAwareStoreHolder(lifecycle, ::createStore)
+    }
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
@@ -5,6 +5,7 @@ import vivid.money.elmslie.android.screen.ElmDelegate
 import vivid.money.elmslie.android.screen.ElmScreen
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.android.util.fastLazy
 
 abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment(), ElmDelegate<Event, Effect, State> {
 
@@ -14,5 +15,7 @@ abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment(),
     protected val store
         get() = storeHolder.store
 
-    override val storeHolder: StoreHolder<Event, Effect, State> = LifecycleAwareStoreHolder(lifecycle, ::createStore)
+    override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
+        LifecycleAwareStoreHolder(lifecycle, ::createStore)
+    }
 }


### PR DESCRIPTION
LifecycleAwareStoreHolder constructor was always called. In case of overriding storeHolder inside children ElmFragment we still have LifecycleAwareStoreHolder with lifecycleObserver inside base ElmFragment. During onDestroy store.stop() inside was called, it leads to the creation of one more store inside LifecycleAwareStoreHolder additionally to store inside overridden child storeHolder.