### PR TITLE
Send init event only once in store lifecycle

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -34,7 +34,7 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
         @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
         fun onCreate() {
             isAfterProcessDeath = ProcessDeathDetector.isRestoringAfterProcessDeath
-            if (isAllowedToRunMvi()) {
+            if (!store.isStarted && isAllowedToRunMvi()) {
                 store.accept(delegate.initEvent)
             }
         }


### PR DESCRIPTION
Now, in case of using retain store holder init event will be sent every time the screen receives an onCreate event. This is not the intended behavior, because most of the time init is supposed to start subscriptions which should happen only once