### PR TITLE
Add support of StopElmOnProcessDeath for Fragments

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
@@ -18,6 +18,8 @@ abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     @Suppress("LeakingThis", "UnusedPrivateMember")
     private val elm = ElmScreen(this, lifecycle) { this }
 
+    override var isAllowedToRunMvi: Boolean = true
+
     protected val store
         get() = storeHolder.store
 

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
@@ -2,6 +2,7 @@ package vivid.money.elmslie.android.base
 
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
+import vivid.money.elmslie.android.processdeath.StopElmOnProcessDeathController
 import vivid.money.elmslie.android.screen.ElmDelegate
 import vivid.money.elmslie.android.screen.ElmScreen
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
@@ -17,6 +18,23 @@ abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment,
 
     @Suppress("LeakingThis", "UnusedPrivateMember")
     private val elm = ElmScreen(this, lifecycle) { requireActivity() }
+
+    override val isAllowedToRunMvi: Boolean
+        get() {
+            var currentFragment: Fragment? = this
+            while (currentFragment != null) {
+                (currentFragment as? StopElmOnProcessDeathController)?.let {
+                    return it.isAllowedToRunMvi
+                }
+                currentFragment = currentFragment.parentFragment
+            }
+
+            (activity as? StopElmOnProcessDeathController)?.let {
+                return it.isAllowedToRunMvi
+            }
+
+            return true
+        }
 
     protected val store
         get() = storeHolder.store

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeath.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeath.kt
@@ -1,3 +1,4 @@
 package vivid.money.elmslie.android.processdeath
 
+@Deprecated("Use delegate.isAllowedToRunMvi instead")
 interface StopElmOnProcessDeath

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeathController.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeathController.kt
@@ -1,0 +1,6 @@
+package vivid.money.elmslie.android.processdeath
+
+interface StopElmOnProcessDeathController {
+
+    val isAllowedToRunMvi: Boolean
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
@@ -10,6 +10,7 @@ interface ElmDelegate<Event : Any, Effect : Any, State : Any> {
 
     val initEvent: Event
     val storeHolder: StoreHolder<Event, Effect, State>
+    val isAllowedToRunMvi: Boolean
 
     fun createStore(): Store<Event, Effect, State>
     fun render(state: State)

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -69,7 +69,8 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
         screenLifecycle.addObserver(lifecycleObserver)
     }
 
-    private fun isAllowedToRunMvi() = !isAfterProcessDeath || activityProvider() !is StopElmOnProcessDeath
+    private fun isAllowedToRunMvi() =
+        delegate.isAllowedToRunMvi && (!isAfterProcessDeath || activityProvider() !is StopElmOnProcessDeath)
 
     private fun observeStates() = store.states
         .skip(1) // skipped first state, because we need to avoid rendering initial state twice

--- a/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
+++ b/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
@@ -23,6 +23,8 @@ abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> : Fr
 
     override val storeHolder = LifecycleAwareStoreHolder(lifecycle, ::createStore)
 
+    override var isAllowedToRunMvi = true
+
     final override fun render(state: State) = Unit
 
     @Composable


### PR DESCRIPTION
For example, we have a MainFragment that redirects to LoginFragment after a process death. It will be wrong to add StopElmOnProcessDeath to Activity because not all Fragments inside this Activity have redirects, but it works like a charm with StopElmOnProcessDeath for Fragments.