### PR TITLE
Fix store isStarted access

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -34,7 +34,7 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
         @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
         fun onCreate() {
             isAfterProcessDeath = ProcessDeathDetector.isRestoringAfterProcessDeath
-            if (!store.isStarted && isAllowedToRunMvi()) {
+            if (!delegate.storeHolder.isStarted && isAllowedToRunMvi()) {
                 store.accept(delegate.initEvent)
             }
         }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
@@ -11,7 +11,9 @@ class LifecycleAwareStoreHolder<Event : Any, Effect : Any, State : Any>(
     storeProvider: () -> Store<Event, Effect, State>,
 ) : StoreHolder<Event, Effect, State> {
 
-    override val store by fastLazy { storeProvider().start() }
+    override var isStarted = false
+
+    override val store by fastLazy { storeProvider().start().also { isStarted = true } }
 
     private val lifecycleObserver: LifecycleObserver = object : LifecycleObserver {
         @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
@@ -10,5 +10,6 @@ import vivid.money.elmslie.core.store.Store
  **/
 interface StoreHolder<Event : Any, Effect : Any, State : Any> {
 
+    val isStarted: Boolean
     val store: Store<Event, Effect, State>
 }

--- a/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
+++ b/elmslie-store-persisting/src/main/java/vivid/money/elmslie/storepersisting/ClearableStoreHolder.kt
@@ -7,7 +7,9 @@ internal class ClearableStoreHolder<Event : Any, Effect : Any, State : Any>(
     storeProvider: () -> Store<Event, Effect, State>,
 ) : StoreHolder<Event, Effect, State> {
 
-    override val store: Store<Event, Effect, State> = storeProvider().start()
+    override var isStarted = false
+
+    override val store by lazy { storeProvider().start().also { isStarted = true } }
 
     fun clear() {
         store.stop()


### PR DESCRIPTION
There was a bug with not sending init event, because StoreHolders always return started stores which breaks isStarted check inside ElmScreen 