### PR TITLE
Store coordination (Conversation rules) 

### DIFF
--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
@@ -14,6 +14,7 @@ interface Store<Event, Effect, State> {
     fun start(): Store<Event, Effect, State>
     fun stop()
 
+    @Deprecated("Please, use store coordination instead. This approach will be removed in future.")
     fun <ChildEvent : Any, ChildState : Any, ChildEffect : Any> addChildStore(
         store: Store<ChildEvent, ChildEffect, ChildState>,
         eventMapper: (parentEvent: Event) -> ChildEvent? = { null },

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversationRules.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversationRules.kt
@@ -1,0 +1,46 @@
+package vivid.money.elmslie.core.store.binding
+
+import vivid.money.elmslie.core.store.Store
+
+/**
+ * A store that supervises both stores and manages their lifecycle.
+ *
+ * With the following responsibilities:
+ * - [start] Starting both stores
+ * - [stop] Stopping both stores
+ *
+ * @param initiator - A store that demands data conversion
+ * @param responder - A store that handles data conversion
+ * @param expecting A conversion contract that [initiator] dispatches for the [responder] to handle
+ * @param receiving A conversion contract that [responder] provides to [initiator] in return
+ * @constructor Determines conversion rules
+ */
+internal class ConversationRules<InitiatorEvent, InitiatorEffect, InitiatorState,
+        ResponderEvent, ResponderEffect, ResponderState>(
+    private val initiator: Store<InitiatorEvent, InitiatorEffect, InitiatorState>,
+    private val responder: Store<ResponderEvent, ResponderEffect, ResponderState>,
+    expecting: ConversionContract<InitiatorEvent, InitiatorEffect, InitiatorState, ResponderEvent,
+            ResponderEffect, ResponderState>.() -> Unit,
+    receiving: ConversionContract<ResponderEvent, ResponderEffect, ResponderState, InitiatorEvent,
+            InitiatorEffect, InitiatorState>.() -> Unit
+) : Store<InitiatorEvent, InitiatorEffect, InitiatorState> by initiator {
+
+    private val providedContract = ConversionContract(initiator, responder).apply(expecting)
+    private val expectedContract = ConversionContract(responder, initiator).apply(receiving)
+
+    override fun start(): Store<InitiatorEvent, InitiatorEffect, InitiatorState> {
+        initiator.start()
+        responder.start()
+        providedContract.apply()
+        expectedContract.apply()
+        return this
+    }
+
+    override fun stop() {
+        providedContract.revoke()
+        expectedContract.revoke()
+        responder.stop()
+        initiator.stop()
+    }
+}
+

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversionContract.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversionContract.kt
@@ -18,17 +18,37 @@ class ConversionContract<InitiatorEvent, InitiatorEffect, InitiatorState,
     private val contracts = mutableSetOf<() -> Unit>()
 
     /**
-     * Defines state conversion between stores
+     * Defines full state conversion between stores
      */
-    fun states(conversion: InitiatorState.() -> ResponderEvent? = { null }) {
-        initiator.states to responder with conversion
+    fun states(
+        conversion: InitiatorState.() -> ResponderEvent? = { null }
+    ) = states({ this }, conversion)
+
+    /**
+     * Defines full effect conversion between stores
+     */
+    fun effects(
+        conversion: InitiatorEffect.() -> ResponderEvent? = { null }
+    ) = effects({ this }, conversion)
+
+    /**
+     * Defines encrypted state conversion between stores
+     */
+    fun <EncryptedState> states(
+        cypher: Observable<InitiatorState>.() -> Observable<EncryptedState>,
+        conversion: EncryptedState.() -> ResponderEvent? = { null }
+    ) {
+        initiator.states.cypher() to responder with conversion
     }
 
     /**
-     * Defines effect conversion between stores
+     * Defines encrypted effect conversion between stores
      */
-    fun effects(conversion: InitiatorEffect.() -> ResponderEvent? = { null }) {
-        initiator.effects to responder with conversion
+    fun <EncryptedEffect> effects(
+        cypher: Observable<InitiatorEffect>.() -> Observable<EncryptedEffect>,
+        conversion: EncryptedEffect.() -> ResponderEvent? = { null }
+    ) {
+        initiator.effects.cypher() to responder with conversion
     }
 
     /**

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversionContract.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/ConversionContract.kt
@@ -1,0 +1,65 @@
+package vivid.money.elmslie.core.store.binding
+
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.disposables.CompositeDisposable
+import vivid.money.elmslie.core.store.Store
+
+/**
+ * A contract for data exchange between stores
+ */
+class ConversionContract<InitiatorEvent, InitiatorEffect, InitiatorState,
+        ResponderEvent, ResponderEffect, ResponderState>(
+    private val initiator: Store<InitiatorEvent, InitiatorEffect, InitiatorState>,
+    private val responder: Store<ResponderEvent, ResponderEffect, ResponderState>,
+) {
+
+    private val disposable = CompositeDisposable()
+    private val contracts = mutableSetOf<() -> Unit>()
+
+    /**
+     * Defines state conversion between stores
+     */
+    fun states(conversion: InitiatorState.() -> ResponderEvent? = { null }) {
+        initiator.states to responder with conversion
+    }
+
+    /**
+     * Defines effect conversion between stores
+     */
+    fun effects(conversion: InitiatorEffect.() -> ResponderEvent? = { null }) {
+        initiator.effects to responder with conversion
+    }
+
+    /**
+     * Defines conversion before passing to another store
+     *
+     * Sample: `manager.states to employee using conversion`
+     */
+    private infix fun <T, Result> Pair<Observable<T>, Store<Result, *, *>>.with(
+        conversion: (T) -> Result?
+    ) {
+        contracts += {
+            first
+                .flatMapMaybe { Maybe.fromCallable<Result> { conversion(it) } }
+                .subscribe(second::accept)
+                .let(disposable::add)
+        }
+    }
+
+    /**
+     * Starts the conversion between stores
+     */
+    fun apply() {
+        check(initiator.isStarted)
+        check(responder.isStarted)
+        contracts.forEach { it() }
+    }
+
+    /**
+     * Stops the conversion between stores
+     */
+    fun revoke() {
+        disposable.clear()
+    }
+}

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/Coordination.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/Coordination.kt
@@ -70,9 +70,6 @@ import vivid.money.elmslie.core.store.Store
  *         states { EmployeeEvent.ImprovementPossibilities(this) }
  *         effects { EmployeeEvent.ResponsibilityExpansion }
  *     }
- *     parent.effects with parent.states to child using { effect, state ->
- *         ChildEvent.First(effect, state)
- *     }
  * }.start()
  * ```
  *

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/Coordination.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/binding/Coordination.kt
@@ -1,0 +1,92 @@
+package vivid.money.elmslie.core.store.binding
+
+import vivid.money.elmslie.core.store.Store
+
+/**
+ * Creates a store that coordinates two stores together.
+ *
+ * Both stores are equal in terms of conversation possibilities.
+ * For the period of the conversion definition the following naming is provided:
+ * - Store which is specified as the receiver is called **initiator**
+ * - Store which is coordinated is called **responder**.
+ *
+ * The resulting store will have the same interface as the **initiator** store.
+ *
+ * Example `Manager-Employee`:
+ * ```
+ * manager.coordinates(
+ *     employee,
+ *     //
+ *     // Manager defines tasks without employee's awareness and dispatches:
+ *     // - Up-to-date task definitions periodically
+ *     // - News about promotion occasionally
+ *     //
+ *     // Employee chooses the way to handle tasks internally without manager's awareness.
+ *     //
+ *     dispatching = {
+ *         states { EmployeeEvent.TaskDefinition(this) }
+ *         effects { EmployeeEffect.PromotionNews }
+ *     },
+ *     //
+ *     // Employee executes tasks without manager's awareness and updates manager with statuses.
+ *     //
+ *     // Manager processes task status updates without employee's awareness when:
+ *     // - Receives up-to-date task status periodically
+ *     // - And appreciates employee occasionally
+ *     //
+ *     receiving = {
+ *         states { ManagerEvent.TaskStatus(this) }
+ *         effects { ManagerEffect.EmployeeAppreciation }
+ *     }
+ * ).start()
+ * ```
+ *
+ * It's possible to define the inverted conversation with another reversed coordination call.
+ *
+ * Example `One-on-one`:
+ * ```
+ * employee.coordinates(
+ *     manager,
+ *     //
+ *     // Employee finds areas of improvement without manager's awareness and dispatches:
+ *     // - Improvement suggestions periodically
+ *     // - Satisfaction for the manager
+ *     //
+ *     // Manager chooses the time to process suggestions without employee's awareness.
+ *     //
+ *     dispatching = {
+ *         states { ManagerEvent.ImprovementSuggestion(this) }
+ *         effects { ManagerEvent.Satisfaction }
+ *     },
+ *     //
+ *     // Manager refines suggestions without employee's awareness
+ *     // and updates employee with possibilities.
+ *     //
+ *     // Employee processes possibilities and makes use of them when:
+ *     // - Receives improvement possibilities
+ *     // - And handles responsibility expansion
+ *     //
+ *     receiving = {
+ *         states { EmployeeEvent.ImprovementPossibilities(this) }
+ *         effects { EmployeeEvent.ResponsibilityExpansion }
+ *     }
+ *     parent.effects with parent.states to child using { effect, state ->
+ *         ChildEvent.First(effect, state)
+ *     }
+ * }.start()
+ * ```
+ *
+ * @receiver - Initiates coordination
+ * @param responder - Supports coordination
+ * @param dispatching - Conversion contract implied by initiator
+ * @param receiving - Conversion contract implied by responder
+ */
+fun <InitiatorEvent, InitiatorEffect, InitiatorState, ResponderEvent, ResponderEffect, ResponderState>
+        Store<InitiatorEvent, InitiatorEffect, InitiatorState>.coordinates(
+    responder: Store<ResponderEvent, ResponderEffect, ResponderState>,
+    dispatching: ConversionContract<InitiatorEvent, InitiatorEffect, InitiatorState,
+            ResponderEvent, ResponderEffect, ResponderState>.() -> Unit = {},
+    receiving: ConversionContract<ResponderEvent, ResponderEffect, ResponderState,
+            InitiatorEvent, InitiatorEffect, InitiatorState>.() -> Unit = {},
+): Store<InitiatorEvent, InitiatorEffect, InitiatorState> =
+    ConversationRules(this, responder, dispatching, receiving)

--- a/elmslie-core/src/test/java/vivid/money/elmslie/core/store/ElmStoreWithChildTest.kt
+++ b/elmslie-core/src/test/java/vivid/money/elmslie/core/store/ElmStoreWithChildTest.kt
@@ -43,7 +43,7 @@ class ElmStoreWithChildTest {
         parent.coordinates(
             child,
             dispatching = {
-                states { ChildEvent.First }
+                states({ filter { true }.map { Any() } }, { ChildEvent.First })
             },
             receiving = {
                 states { ParentEvent.ChildUpdated(this) }

--- a/elmslie-core/src/test/java/vivid/money/elmslie/core/testutil/model/ParentModels.kt
+++ b/elmslie-core/src/test/java/vivid/money/elmslie/core/testutil/model/ParentModels.kt
@@ -1,6 +1,9 @@
 package vivid.money.elmslie.core.testutil.model
 
-object ParentEvent
+sealed class ParentEvent {
+    object Plain : ParentEvent()
+    data class ChildUpdated(val state: ChildState) : ParentEvent()
+}
 data class ParentState(val value: Int = 0, val childValue: Int = 0)
 object ParentEffect
 object ParentCommand


### PR DESCRIPTION
## What is it?
This merge request enables a new approach for defining communication between stores

## Why is this needed?
The current implementation has some disadvantages:
-  Limits communication possibilities
Only event to event and effect to effect mappings
- Has strict contract
Events are mapped without state and effects may access parent state
- Defines strict parent - child relationship
Instead of making stores as indepent as possible
- Allows to access internal implementation details
Events by nature contain a private store information. Internal events are named this way obviously  to represent **internal events**
- There's no way to trigger an event in the parent from the child store
There are other possibilities to workaround this, but it seems like the right time to make this change.
The case which lead to this change:
  - Parent store along with parent fragment are immutable and kept in the common module
  - Child stores are plugins to the parent store and fragment
  - Child stores need to trigger some event in parent


## Why is the new approach better?
It has some advantages:
- Allow to contruct any communication mechanism
It has an api for defining communication contract
- Communication contract may access only public api defined in the Store interface
Instead of accessing implementation details

## Is this api backwards-compatible?
No, the old api is kept to allow postponing migration

## How to migrate to the new api?
There's no way to migrate easily to the new api, because there's no way to map events to events and effects to effects

## How to migrate?
### Effect to effect
Consume child effects in the parent and send effects directly OR consume effects in the fragment (Api for using multiple stores in the fragment is planned in some distant future)
### Event to event
Replace consumable child events with effects

## The main questions
- Do you agree that this is an appropriate change?  
- Will you be able to handle migration?
- Do you need more apis for easier migration?
- Are there any structural incompetibilities which can't be implemented with new apis?