### PR TITLE
Make effects buffer's replay subject serialized

### DIFF
--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectsBuffer.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectsBuffer.kt
@@ -4,6 +4,7 @@ import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.subjects.PublishSubject
 import io.reactivex.rxjava3.subjects.ReplaySubject
+import io.reactivex.rxjava3.subjects.Subject
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -15,7 +16,7 @@ internal class EffectsBuffer<T>(
 ) : AtomicBoolean(), Disposable {
 
     private val disposableRef = AtomicReference<Disposable>()
-    private val bufferRef = AtomicReference<ReplaySubject<T>>()
+    private val bufferRef = AtomicReference<Subject<T>>()
 
     fun init(): Disposable {
         startBuffering()
@@ -37,7 +38,7 @@ internal class EffectsBuffer<T>(
     }
 
     private fun startBuffering() {
-        val buffer = ReplaySubject.create<T>()
+        val buffer = ReplaySubject.create<T>().toSerialized()
         bufferRef.set(buffer)
         disposableRef.set(source.subscribe { buffer.onNext(it) })
     }


### PR DESCRIPTION
Our most common crash happened because of class cast exceptions inside NotificationLite.java:190 (ReplaySubject.java:782) after restoring fragments from the background. 

Classes were obfuscated and I failed to reproduce this issue. But during reviewing sources I noticed that we call subject.onNext from computation threads and call onComplete from the main thread. And the last object inside the ReplaySubject queue wasn't a complete event, but some live event. I assume that it can be fixed by making ReplaySubject serialized.

<details open>
<summary>Crash log</summary>

```
io.reactivex.rxjava3.internal.util.NotificationLite.getError (NotificationLite.java:190)
io.reactivex.rxjava3.subjects.ReplaySubject$UnboundedReplayBuffer.replay (ReplaySubject.java:782)
io.reactivex.rxjava3.subjects.ReplaySubject.subscribeActual (ReplaySubject.java:344)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableDefer.subscribeActual (ObservableDefer.java:40)
io.reactivex.rxjava3.internal.operators.observable.ObservableDefer.subscribeActual$bridge (ObservableDefer.java:5)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableConcatMap$ConcatMapDelayErrorObserver.drain (ObservableConcatMap.java:469)
io.reactivex.rxjava3.internal.operators.observable.ObservableConcatMap$ConcatMapDelayErrorObserver.onSubscribe (ObservableConcatMap.java:330)
io.reactivex.rxjava3.internal.operators.observable.ObservableFromArray.subscribeActual (ObservableFromArray.java:32)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableConcatMap.subscribeActual (ObservableConcatMap.java:56)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableDoFinally.subscribeActual (ObservableDoFinally.java:43)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableDoOnLifecycle.subscribeActual (ObservableDoOnLifecycle.java:34)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableDoOnEach.subscribeActual (ObservableDoOnEach.java:42)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableRetryPredicate$RepeatObserver.subscribeNext (ObservableRetryPredicate.java:112)
io.reactivex.rxjava3.internal.operators.observable.ObservableRetryPredicate.subscribeActual (ObservableRetryPredicate.java:41)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.internal.operators.observable.ObservableObserveOn.subscribeActual (ObservableObserveOn.java:46)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13176)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13121)
io.reactivex.rxjava3.core.Observable.subscribe (Observable.java:13059)
vivid.money.elmslie.android.screen.ElmScreen.observeEffects (ElmScreen.java:94)
vivid.money.elmslie.android.screen.ElmScreen.access$observeEffects (ElmScreen.java:17)
vivid.money.elmslie.android.screen.ElmScreen$lifecycleObserver$1.onResume (ElmScreen.kt:52)
```
</details>