### PR TITLE
Fix Effects Coordination

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -33,6 +33,7 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
         override fun onCreate(owner: LifecycleOwner) {
             isAfterProcessDeath = ProcessDeathDetector.isRestoringAfterProcessDeath
             if (!delegate.storeHolder.isStarted && isAllowedToRunMvi()) {
+                store.startEffectsBuffering()
                 store.accept(delegate.initEvent)
             }
         }
@@ -46,9 +47,11 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
 
         override fun onResume(owner: LifecycleOwner) {
             effectsDisposable = observeEffects()
+            store.stopEffectsBuffering()
         }
 
         override fun onPause(owner: LifecycleOwner) {
+            store.startEffectsBuffering()
             effectsDisposable?.dispose()
             effectsDisposable = null
         }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -33,7 +33,6 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
         override fun onCreate(owner: LifecycleOwner) {
             isAfterProcessDeath = ProcessDeathDetector.isRestoringAfterProcessDeath
             if (!delegate.storeHolder.isStarted && isAllowedToRunMvi()) {
-                store.startEffectsBuffering()
                 store.accept(delegate.initEvent)
             }
         }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectsBuffer.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectsBuffer.kt
@@ -26,8 +26,6 @@ internal class EffectsBuffer<T>(
     fun getBufferedObservable(): Observable<T> {
         return getBuffer() // Get buffered events
             .concatWith(source) // And then start observing the source
-            .doFinally { startBuffering() } // Start buffering again to not lose events from source
-            .doOnSubscribe { stopBuffering() } // Stop buffering since we're getting events from source
     }
 
     override fun isDisposed(): Boolean = get()
@@ -37,13 +35,13 @@ internal class EffectsBuffer<T>(
         stopBuffering()
     }
 
-    private fun startBuffering() {
+    fun startBuffering() {
         val buffer = ReplaySubject.create<T>().toSerialized()
         bufferRef.set(buffer)
         disposableRef.set(source.subscribe { buffer.onNext(it) })
     }
 
-    private fun stopBuffering() {
+    fun stopBuffering() {
         bufferRef.get()?.onComplete()
         disposableRef.get()?.dispose()
     }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -132,5 +132,13 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
         return this
     }
 
+    override fun startEffectsBuffering() {
+        effectsBuffer.startBuffering()
+    }
+
+    override fun stopEffectsBuffering() {
+        effectsBuffer.stopBuffering()
+    }
+
     private fun Disposable.bind() = let(disposables::add)
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
@@ -12,6 +12,8 @@ interface Store<Event, Effect, State> {
 
     val isStarted: Boolean
     fun start(): Store<Event, Effect, State>
+    fun startEffectsBuffering()
+    fun stopEffectsBuffering()
     fun stop()
 
     @Deprecated("Please, use store coordination instead. This approach will be removed in future.")

--- a/elmslie-core/src/test/java/vivid/money/elmslie/core/store/EffectsBufferTest.kt
+++ b/elmslie-core/src/test/java/vivid/money/elmslie/core/store/EffectsBufferTest.kt
@@ -10,9 +10,11 @@ class EffectsBufferTest {
 
         val dataObservable = PublishSubject.create<Int>()
 
-        val buffer = EffectsBuffer(dataObservable).apply { init() }.getBufferedObservable()
+        val buffer = EffectsBuffer(dataObservable).apply { init() }
+        val bufferObservable = buffer.getBufferedObservable()
 
-        val testObserver = buffer.test()
+        buffer.stopBuffering()
+        val testObserver = bufferObservable.test()
 
         // emitting items while subscribed
         with(dataObservable) {
@@ -21,6 +23,7 @@ class EffectsBufferTest {
         }
 
         testObserver.assertValues(1, 2)
+        buffer.startBuffering()
         testObserver.dispose()
 
         // emitting items while detached
@@ -29,7 +32,8 @@ class EffectsBufferTest {
             onNext(4)
         }
 
-        val anotherObserver = buffer.test()
+        val anotherObserver = bufferObservable.test()
+        buffer.stopBuffering()
         anotherObserver.assertValues(3, 4)
 
         // emitting item when attached with having items in buffer

--- a/elmslie-core/src/test/java/vivid/money/elmslie/core/testutil/model/ParentModels.kt
+++ b/elmslie-core/src/test/java/vivid/money/elmslie/core/testutil/model/ParentModels.kt
@@ -5,5 +5,8 @@ sealed class ParentEvent {
     data class ChildUpdated(val state: ChildState) : ParentEvent()
 }
 data class ParentState(val value: Int = 0, val childValue: Int = 0)
-object ParentEffect
+sealed interface ParentEffect {
+    object ToParent : ParentEffect
+    data class ToChild(val childEvent: ChildEvent) : ParentEffect
+}
 object ParentCommand


### PR DESCRIPTION
The issue can be described as "Parent effects are getting lost before they are observed by ElmScreen".  
This was happening because of the encapsulated behavior of `EffectsBuffer` to stop buffering upon first subscription. But the first subscription was done by the store coordination thus effects were lost. This PR is to fix it.