### PR TITLE
Allow to publish from other branches

### DIFF
--- a/.github/sh/validate_main_branch.sh
+++ b/.github/sh/validate_main_branch.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-if [[ ${GITHUB_REF##*/} != "main" ]]; then
-  echo "::error ::Can only release from main branch"
-  exit 1
-fi

--- a/.github/sh/validate_publishing_branch.sh
+++ b/.github/sh/validate_publishing_branch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ ${GITHUB_REF##*/} == main ]]; then
+  # Safe to publish from main branch
+  exit 0
+elif [[ ${GITHUB_REF##*/} == publish* ]]; then
+  # Safe to publish from branches that have manually enabled publishing
+  exit 0
+else
+  echo "::error ::Can only release from main branch or branches that start with 'publish'"
+  exit 1
+fi

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Ensure main branch
-        run: ./.github/sh/validate_main_branch.sh
+        run: ./.github/sh/validate_publishing_branch.sh
 
       - name: Validate plugin version update
         run: ./.github/sh/validate_version_update.sh "pluginVersion" "$NEW_VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Ensure main branch
-        run: ./.github/sh/validate_main_branch.sh
+        run: ./.github/sh/validate_publishing_branch.sh
 
       - name: Validate library version update
         run: ./.github/sh/validate_version_update.sh "libraryVersion" "$NEW_VERSION"


### PR DESCRIPTION
This merge request allows to publish library releases for branches starting with `publish`.