### PR TITLE
Support android 12 backup rules

### DIFF
--- a/elmslie-samples/android-loader/src/main/AndroidManifest.xml
+++ b/elmslie-samples/android-loader/src/main/AndroidManifest.xml
@@ -1,17 +1,19 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        package="vivid.money.elmslie.samples.android.loader">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="vivid.money.elmslie.samples.android.loader">
 
     <application
-            android:name=".App"
-            android:allowBackup="false"
-            android:icon="@mipmap/ic_launcher"
-            android:label="@string/app_name"
-            android:supportsRtl="false"
-            android:theme="@style/AppTheme"
-            tools:ignore="GoogleAppIndexingWarning"
-            tools:replace="android:supportsRtl">
-        <activity android:name=".MainActivity"
+        android:name=".App"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/disable_backup"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:supportsRtl="false"
+        android:theme="@style/AppTheme"
+        tools:ignore="DataExtractionRules,GoogleAppIndexingWarning,UnusedAttribute"
+        tools:replace="android:supportsRtl">
+        <activity
+            android:name=".MainActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/elmslie-samples/android-loader/src/main/res/xml/disable_backup.xml
+++ b/elmslie-samples/android-loader/src/main/res/xml/disable_backup.xml
@@ -1,0 +1,16 @@
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>

--- a/elmslie-samples/compose-paging/src/main/AndroidManifest.xml
+++ b/elmslie-samples/compose-paging/src/main/AndroidManifest.xml
@@ -3,12 +3,12 @@
     package="vivid.money.elmslie.samples.android.compose">
 
     <application
-        android:allowBackup="false"
+        android:dataExtractionRules="@xml/disable_backup"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="false"
         android:theme="@style/AppTheme"
-        tools:ignore="GoogleAppIndexingWarning"
+        tools:ignore="DataExtractionRules,GoogleAppIndexingWarning,UnusedAttribute"
         tools:replace="android:supportsRtl">
         <activity
             android:name="vivid.money.elmslie.samples.android.compose.view.MainActivity"

--- a/elmslie-samples/compose-paging/src/main/res/xml/disable_backup.xml
+++ b/elmslie-samples/compose-paging/src/main/res/xml/disable_backup.xml
@@ -1,0 +1,16 @@
+<data-extraction-rules>
+    <cloud-backup>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" />
+        <exclude domain="file" />
+        <exclude domain="database" />
+        <exclude domain="sharedpref" />
+        <exclude domain="external" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
Add support for new backup rules, because`android:allowBackup="false"` is deprecated