### PR TITLE
Add basic UI tests

### DIFF
--- a/elmslie-samples/android-loader/build.gradle
+++ b/elmslie-samples/android-loader/build.gradle
@@ -6,6 +6,22 @@ plugins {
 android {
     buildFeatures.buildConfig = true
     defaultConfig.multiDexEnabled true
+
+    defaultConfig {
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["clearPackageData"] = "true"
+    }
+
+    testOptions {
+        execution = "ANDROIDX_TEST_ORCHESTRATOR"
+        unitTests.returnDefaultValues = true
+        unitTests.includeAndroidResources = true
+    }
+
+    packagingOptions {
+        exclude 'META-INF/LICENSE.md'
+        exclude 'META-INF/LICENSE-notice.md'
+    }
 }
 
 dependencies {
@@ -17,6 +33,12 @@ dependencies {
     implementation(deps.android.material)
     implementation(deps.android.multidex)
     implementation(deps.rx.rxJava2)
+
+    androidTestImplementation(deps.uitest.core)
+    androidTestImplementation(deps.uitest.junit)
+    androidTestImplementation(deps.uitest.kaspresso)
+
+    androidTestUtil(deps.uitest.orchestrator)
 }
 
 apply from: "../../gradle/junit-5.gradle"

--- a/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/MainScreen.kt
+++ b/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/MainScreen.kt
@@ -1,0 +1,18 @@
+package vivid.money.elmslie.samples.android.loader
+
+import com.kaspersky.kaspresso.screens.KScreen
+import io.github.kakaocup.kakao.text.KButton
+import io.github.kakaocup.kakao.text.KSnackbar
+import io.github.kakaocup.kakao.text.KTextView
+
+object MainScreen : KScreen<MainScreen>() {
+
+    override val layoutId: Int = R.layout.activity_main
+    override val viewClass: Class<*> = MainActivity::class.java
+
+    val reload = KButton { withId(R.id.reload) }
+
+    val currentValue = KTextView { withId(R.id.currentValue) }
+
+    val snackbar = KSnackbar()
+}

--- a/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/MainScreenTest.kt
+++ b/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/MainScreenTest.kt
@@ -1,0 +1,72 @@
+package vivid.money.elmslie.samples.android.loader
+
+import androidx.test.rule.ActivityTestRule
+import com.kaspersky.kaspresso.testcases.api.testcase.TestCase
+import io.reactivex.plugins.RxJavaPlugins
+import io.reactivex.schedulers.TestScheduler
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import vivid.money.elmslie.samples.android.loader.repository.ValueRepository
+import vivid.money.elmslie.samples.android.loader.scenario.ErrorStateScenario
+import vivid.money.elmslie.samples.android.loader.scenario.LoadingScreenScenario
+import vivid.money.elmslie.samples.android.loader.scenario.NumberStateScenario
+import java.util.concurrent.TimeUnit
+
+class MainScreenTest : TestCase() {
+
+    @get:Rule
+    val activityTestRule = ActivityTestRule(MainActivity::class.java, true, false)
+
+    private val scheduler = TestScheduler()
+
+    @Before
+    fun mockScheduler() {
+        RxJavaPlugins.setIoSchedulerHandler { scheduler }
+        RxJavaPlugins.setComputationSchedulerHandler { scheduler }
+        RxJavaPlugins.setNewThreadSchedulerHandler { scheduler }
+
+        activityTestRule.launchActivity(null)
+    }
+
+    @After
+    fun resetSchedulers() = RxJavaPlugins.reset()
+
+    @Test
+    fun appStartsWithLoadingScreen() = run {
+        scenario(LoadingScreenScenario())
+    }
+
+    @Test
+    fun errorStateIsDisplayedAfterError() = run {
+        ValueRepository.predefineError()
+
+        scenario(LoadingScreenScenario())
+
+        scheduler.advanceTimeBy(5, TimeUnit.SECONDS)
+
+        scenario(ErrorStateScenario())
+    }
+
+    @Test
+    fun reloadingAfterErrorMayShowSomeNumber() = run {
+        ValueRepository.predefineError()
+
+        scenario(LoadingScreenScenario())
+        scheduler.advanceTimeBy(5, TimeUnit.SECONDS)
+        scenario(ErrorStateScenario())
+
+        MainScreen.reload.click()
+        scenario(LoadingScreenScenario())
+    }
+
+    @Test
+    fun numberIsDisplayingAfterLoading() = run {
+        ValueRepository.predefineNumber(10)
+
+        scenario(LoadingScreenScenario())
+        scheduler.advanceTimeBy(5, TimeUnit.SECONDS)
+        scenario(NumberStateScenario(10))
+    }
+}

--- a/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/ErrorStateScenario.kt
+++ b/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/ErrorStateScenario.kt
@@ -1,0 +1,16 @@
+package vivid.money.elmslie.samples.android.loader.scenario
+
+import com.kaspersky.kaspresso.testcases.api.scenario.BaseScenario
+import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
+import vivid.money.elmslie.samples.android.loader.MainScreen
+
+class ErrorStateScenario : BaseScenario<Unit>() {
+    override val steps: TestContext<Unit>.() -> Unit = {
+        step("Error state is displayed") {
+            MainScreen {
+                snackbar.text.hasText("Error!")
+                currentValue.hasText("Value = Unknown")
+            }
+        }
+    }
+}

--- a/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/LoadingScreenScenario.kt
+++ b/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/LoadingScreenScenario.kt
@@ -1,0 +1,15 @@
+package vivid.money.elmslie.samples.android.loader.scenario
+
+import com.kaspersky.kaspresso.testcases.api.scenario.BaseScenario
+import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
+import vivid.money.elmslie.samples.android.loader.MainScreen
+
+class LoadingScreenScenario : BaseScenario<Unit>() {
+    override val steps: TestContext<Unit>.() -> Unit = {
+        step("LoadingScreen is displayed") {
+            MainScreen {
+                currentValue.hasText("Loading...")
+            }
+        }
+    }
+}

--- a/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/NumberStateScenario.kt
+++ b/elmslie-samples/android-loader/src/androidTest/java/vivid/money/elmslie/samples/android/loader/scenario/NumberStateScenario.kt
@@ -1,0 +1,18 @@
+package vivid.money.elmslie.samples.android.loader.scenario
+
+import com.kaspersky.kaspresso.testcases.api.scenario.BaseScenario
+import com.kaspersky.kaspresso.testcases.core.testcontext.TestContext
+import vivid.money.elmslie.samples.android.loader.MainScreen
+
+class NumberStateScenario(
+    private val number: Int
+) : BaseScenario<Unit>() {
+
+    override val steps: TestContext<Unit>.() -> Unit = {
+        step("Number is displayed") {
+            MainScreen {
+                currentValue.hasText("Value = $number")
+            }
+        }
+    }
+}

--- a/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/repository/ValueRepository.kt
+++ b/elmslie-samples/android-loader/src/main/java/vivid/money/elmslie/samples/android/loader/repository/ValueRepository.kt
@@ -6,10 +6,22 @@ import java.util.concurrent.TimeUnit
 
 object ValueRepository {
 
+    private val predefinedValues = LinkedList<Pair<Boolean, Int>>()
     private val random = Random()
 
     @Suppress("MagicNumber")
-    fun getValue() = Single.timer(random.nextLong() % 2000 + 1000, TimeUnit.MILLISECONDS)
-        .map { random.nextInt() }
-        .doOnSuccess { if (it % 3 == 1) error("Simulate unexpected error") }
+    fun getValue() = Single
+        .timer(random.nextLong() % 2000 + 1000, TimeUnit.MILLISECONDS)
+        .map { calculateValue() }
+
+    private fun calculateValue(): Int {
+        if (predefinedValues.isEmpty()) return random.nextInt()
+        val (isNumber, number) = predefinedValues.pop()
+        if (isNumber) return number
+        error("Simulated error")
+    }
+
+    fun predefineError() = predefinedValues.push(false to 0)
+
+    fun predefineNumber(number: Int) = predefinedValues.push(true to number)
 }

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -3,7 +3,7 @@ ext.versions = [
 ]
 
 ext.deps = [
-        gradle : [
+        gradle    : [
                 androidPlugin : "com.android.tools.build:gradle:7.0.4",
                 kotlinPlugin  : "org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10",
                 intellijPlugin: "org.jetbrains.intellij.plugins:gradle-intellij-plugin:1.3.0",
@@ -20,7 +20,7 @@ ext.deps = [
                 material                    : "com.google.android.material:material:1.5.0",
                 multidex                    : "androidx.multidex:multidex:2.0.1",
         ],
-        compose: [
+        compose   : [
                 activity      : "androidx.activity:activity-compose:1.4.0",
                 foundation    : "androidx.compose.foundation:foundation:1.0.5",
                 iconsCore     : "androidx.compose.material:material-icons-core:1.0.5",
@@ -47,6 +47,12 @@ ext.deps = [
                 kotestJunitRunner: "io.kotest:kotest-runner-junit5-jvm:5.1.0",
                 kotestAssertions : "io.kotest:kotest-assertions-core:5.1.0",
                 kotestProperty   : "io.kotest:kotest-property:5.1.0",
+        ],
+        uitest    : [
+                kaspresso   : "com.kaspersky.android-components:kaspresso:1.4.1",
+                orchestrator: "androidx.test:orchestrator:1.4.1",
+                junit       : "androidx.test.ext:junit:1.1.3",
+                core : "androidx.test:core:1.4.0",
         ],
         plugin    : [
                 freemarker: "org.freemarker:freemarker:2.3.31",


### PR DESCRIPTION
This merge requests adds very basic ui tests for `android-loader` sample to verify library integrity before releases. Right now the tests should be run locally and manually before every release.