### PR TITLE
Fix test libs releases

### DIFF
--- a/elmslie-test-rxjava-3/build.gradle
+++ b/elmslie-test-rxjava-3/build.gradle
@@ -9,5 +9,6 @@ dependencies {
     implementation(deps.rx.rxJava3)
 }
 
+apply from: "../gradle/kotlin-publishing.gradle"
 apply from: "../gradle/android-lint.gradle"
 apply from: "../gradle/detekt.gradle"

--- a/elmslie-test/build.gradle
+++ b/elmslie-test/build.gradle
@@ -9,5 +9,6 @@ dependencies {
     implementation(deps.rx.rxJava3)
 }
 
+apply from: "../gradle/kotlin-publishing.gradle"
 apply from: "../gradle/android-lint.gradle"
 apply from: "../gradle/detekt.gradle"

--- a/gradle/android-publishing.gradle
+++ b/gradle/android-publishing.gradle
@@ -5,7 +5,7 @@ group = libraryGroup
 version = libraryVersion
 
 project.tasks.dokkaJavadoc.configure {
-    outputDirectory.set(new File("javadoc", project.buildDir))
+    outputDirectory.set(new File(project.buildDir, "javadoc"))
     moduleName = rootProject.name
 }
 


### PR DESCRIPTION
Fix missed elmslie-test and elmslie-test-rxjava3 artifacts in Jitpack.

I'm not sure that it should work like this for publishing to Jitpack, but at least these artifacts appear in maven locals after `publishToMavenLocal`