### PR TITLE
Fix missed effects

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -37,7 +37,7 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
     }
 
     private fun observeEffects() = store.effects {
-        effectHandler.postSingle {
+        effectHandler.post {
             catchEffectErrors {
                 delegate.handleEffect(it)
             }


### PR DESCRIPTION
A good example is when a store reduces event and produce two effects. With the current implementation, only one will be processed. I believe that we don't need to use `postSingle` for effects.