### PR TITLE
Fix buffering behaviour

### DIFF
--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -42,7 +42,7 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
 
     override fun start() = this.also {
         requireNotStarted()
-        stopBuffering()
+        startBuffering()
     }
 
     override fun stop() {

--- a/elmslie-core/src/test/java/vivid/money/elmslie/core/store/ElmStoreTest.kt
+++ b/elmslie-core/src/test/java/vivid/money/elmslie/core/store/ElmStoreTest.kt
@@ -127,6 +127,29 @@ class ElmStoreTest {
     }
 
     @Test
+    fun `Emitted effect that was received before subscribe to effects`() {
+        val store = store(
+            State(),
+            { event, state ->
+                Result(state = state, effect = Effect(value = event.value))
+            }
+        ).start()
+
+        val effects = mutableListOf<Effect>()
+        store.accept(Event(value = 1))
+        store.effects(effects::add)
+        store.accept(Event(value = -1))
+
+        assertEquals(
+            mutableListOf(
+                Effect(value = 1), // The first effect
+                Effect(value = -1), // The second effect
+            ),
+            effects
+        )
+    }
+
+    @Test
     fun `Command result is observed by store`() {
         val store = store(
             State(),


### PR DESCRIPTION
If an effect is produced after accepting the init event inside fragment onCreate (ElmScreen onCreate) in the same thread, it should be consumed by the first effect subscription.