### PR TITLE
Add a new way to connect stores

### DIFF
--- a/elmslie-android/build.gradle
+++ b/elmslie-android/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation(deps.android.appStartup)
     implementation(deps.android.lifecycle)
     implementation(deps.android.lifecycleKtx)
+    implementation(deps.android.lifecycleViewModelSavedState)
     implementation(deps.android.paging)
 }
 

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
@@ -16,21 +16,22 @@ abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
 
     constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
 
-    @Suppress("LeakingThis", "UnusedPrivateMember")
-    private val elm = ElmScreen(this, lifecycle) { this }
+    @Suppress("LeakingThis", "UnusedPrivateMember") private val elm = ElmScreen(this, lifecycle)
 
-    protected val store
+    override val store
         get() = storeHolder.store
 
-    override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
+    private val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
         createStoreHolder { createStore() }
     }
 
-    override fun createStoreHolder(
+    open fun createStoreHolder(
         storeProvider: () -> Store<Event, Effect, State>
     ): StoreHolder<Event, Effect, State> =
         LifecycleAwareStoreHolder(
             lifecycle = lifecycle,
             storeProvider = storeProvider,
         )
+
+    abstract fun createStore(): Store<Event, Effect, State>
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmActivity.kt
@@ -7,6 +7,7 @@ import vivid.money.elmslie.android.screen.ElmScreen
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.android.util.fastLazy
+import vivid.money.elmslie.core.store.Store
 
 abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
     AppCompatActivity, ElmDelegate<Event, Effect, State> {
@@ -22,6 +23,14 @@ abstract class ElmActivity<Event : Any, Effect : Any, State : Any> :
         get() = storeHolder.store
 
     override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
-        LifecycleAwareStoreHolder(lifecycle) { createStore()!! }
+        createStoreHolder { createStore() }
     }
+
+    override fun createStoreHolder(
+        storeProvider: () -> Store<Event, Effect, State>
+    ): StoreHolder<Event, Effect, State> =
+        LifecycleAwareStoreHolder(
+            lifecycle = lifecycle,
+            storeProvider = storeProvider,
+        )
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
@@ -7,9 +7,10 @@ import vivid.money.elmslie.android.screen.ElmScreen
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.android.util.fastLazy
+import vivid.money.elmslie.core.store.Store
 
-abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment,
-    ElmDelegate<Event, Effect, State> {
+abstract class ElmFragment<Event : Any, Effect : Any, State : Any> :
+    Fragment, ElmDelegate<Event, Effect, State> {
 
     constructor() : super()
 
@@ -22,6 +23,14 @@ abstract class ElmFragment<Event : Any, Effect : Any, State : Any> : Fragment,
         get() = storeHolder.store
 
     override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
-        LifecycleAwareStoreHolder(lifecycle) { createStore()!! }
+        createStoreHolder { createStore() }
     }
+
+    override fun createStoreHolder(
+        storeProvider: () -> Store<Event, Effect, State>
+    ): StoreHolder<Event, Effect, State> =
+        LifecycleAwareStoreHolder(
+            lifecycle = lifecycle,
+            storeProvider = storeProvider,
+        )
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/base/ElmFragment.kt
@@ -16,21 +16,22 @@ abstract class ElmFragment<Event : Any, Effect : Any, State : Any> :
 
     constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
 
-    @Suppress("LeakingThis", "UnusedPrivateMember")
-    private val elm = ElmScreen(this, lifecycle) { requireActivity() }
+    @Suppress("LeakingThis", "UnusedPrivateMember") private val elm = ElmScreen(this, lifecycle)
 
-    protected val store
+    override val store
         get() = storeHolder.store
 
-    override val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
+    private val storeHolder: StoreHolder<Event, Effect, State> by fastLazy {
         createStoreHolder { createStore() }
     }
 
-    override fun createStoreHolder(
+    open fun createStoreHolder(
         storeProvider: () -> Store<Event, Effect, State>
     ): StoreHolder<Event, Effect, State> =
         LifecycleAwareStoreHolder(
             lifecycle = lifecycle,
             storeProvider = storeProvider,
         )
+
+    abstract fun createStore(): Store<Event, Effect, State>
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ElmManager.kt
@@ -1,0 +1,7 @@
+package vivid.money.elmslie.android.manager
+
+import vivid.money.elmslie.core.store.Store
+
+interface ElmManager<Event : Any, Effect : Any, State : Any> {
+    val store: Store<Event, Effect, State>
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ElmManager.kt
@@ -1,7 +1,59 @@
 package vivid.money.elmslie.android.manager
 
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.store.Store
 
-interface ElmManager<Event : Any, Effect : Any, State : Any> {
-    val store: Store<Event, Effect, State>
+abstract class ElmManager<Event : Any, Effect : Any, State : Any>(
+    storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
+    key: String,
+    getViewModelStoreOwner: () -> ViewModelStoreOwner,
+    getSavedStateRegistryOwner: () -> SavedStateRegistryOwner,
+    getDefaultArgs: () -> Bundle,
+) {
+    val store: Store<Event, Effect, State> by fastLazy {
+        val factory =
+            RetainedViewModelFactory(
+                stateRegistryOwner = getSavedStateRegistryOwner.invoke(),
+                defaultArgs = getDefaultArgs.invoke(),
+                storeFactory = storeFactory,
+            )
+        val provider = ViewModelProvider(getViewModelStoreOwner.invoke(), factory)
+
+        @Suppress("UNCHECKED_CAST")
+        provider.get(key, RetainedViewModel::class.java).store as Store<Event, Effect, State>
+    }
+}
+
+private class RetainedViewModel<Event : Any, Effect : Any, State : Any>(
+    savedStateHandle: SavedStateHandle,
+    storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
+) : ViewModel() {
+
+    val store by fastLazy { storeFactory.invoke(savedStateHandle).apply { start() } }
+
+    override fun onCleared() {
+        store.stop()
+    }
+}
+
+private class RetainedViewModelFactory<Event : Any, Effect : Any, State : Any>(
+    stateRegistryOwner: SavedStateRegistryOwner,
+    defaultArgs: Bundle,
+    private val storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
+) : AbstractSavedStateViewModelFactory(stateRegistryOwner, defaultArgs) {
+
+    override fun <T : ViewModel> create(
+        key: String,
+        modelClass: Class<T>,
+        handle: SavedStateHandle
+    ): T {
+        @Suppress("UNCHECKED_CAST") return RetainedViewModel(handle, storeFactory) as T
+    }
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
@@ -1,17 +1,29 @@
 package vivid.money.elmslie.android.manager
 
+import android.os.Bundle
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
 import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
-import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.store.Store
 
 class ViewBasedElmManager<Event : Any, Effect : Any, State : Any>(
-    storeProvider: () -> Store<Event, Effect, State>,
+    storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
     screenLifecycle: Lifecycle,
     initEventProvider: () -> Event,
-) : ElmManager<Event, Effect, State> {
-
-    override val store: Store<Event, Effect, State> by fastLazy { storeProvider.invoke() }
+    key: String,
+    getViewModelStoreOwner: () -> ViewModelStoreOwner,
+    getSavedStateRegistryOwner: () -> SavedStateRegistryOwner,
+    getDefaultArgs: () -> Bundle,
+) :
+    ElmManager<Event, Effect, State>(
+        key = key,
+        getViewModelStoreOwner = getViewModelStoreOwner,
+        getSavedStateRegistryOwner = getSavedStateRegistryOwner,
+        getDefaultArgs = getDefaultArgs,
+        storeFactory = storeFactory,
+    ) {
 
     @Suppress("LeakingThis", "UnusedPrivateMember")
     private val storeStarter: ViewBasedStoreStarter<Event> =

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
@@ -1,6 +1,5 @@
 package vivid.money.elmslie.android.manager
 
-import android.app.Activity
 import androidx.lifecycle.Lifecycle
 import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
@@ -11,7 +10,6 @@ class ViewBasedElmManager<Event : Any, Effect : Any, State : Any>(
     storeCreator: () -> Store<Event, Effect, State>,
     screenLifecycle: Lifecycle,
     initEventProvider: () -> Event,
-    activityProvider: () -> Activity
 ) : ElmManager<Event, Effect, State> {
 
     override val store: Store<Event, Effect, State>
@@ -26,6 +24,5 @@ class ViewBasedElmManager<Event : Any, Effect : Any, State : Any>(
             storeHolder = storeHolder,
             screenLifecycle = screenLifecycle,
             initEventProvider = initEventProvider,
-            activityProvider = activityProvider,
         )
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
@@ -1,0 +1,31 @@
+package vivid.money.elmslie.android.manager
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
+import vivid.money.elmslie.core.store.Store
+
+class ViewBasedElmManager<Event : Any, Effect : Any, State : Any>(
+    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State>,
+    storeCreator: () -> Store<Event, Effect, State>,
+    screenLifecycle: Lifecycle,
+    initEventProvider: () -> Event,
+    activityProvider: () -> Activity
+) : ElmManager<Event, Effect, State> {
+
+    override val store: Store<Event, Effect, State>
+        get() = storeHolder.store
+
+    private val storeHolder: StoreHolder<Event, Effect, State> =
+        storeHolderFactory.invoke(storeCreator)
+
+    @Suppress("LeakingThis", "UnusedPrivateMember")
+    private val storeStarter: ViewBasedStoreStarter<Event, Effect, State> =
+        ViewBasedStoreStarter(
+            storeHolder = storeHolder,
+            screenLifecycle = screenLifecycle,
+            initEventProvider = initEventProvider,
+            activityProvider = activityProvider,
+        )
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManager.kt
@@ -1,27 +1,22 @@
 package vivid.money.elmslie.android.manager
 
 import androidx.lifecycle.Lifecycle
-import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
+import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.store.Store
 
 class ViewBasedElmManager<Event : Any, Effect : Any, State : Any>(
-    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State>,
-    storeCreator: () -> Store<Event, Effect, State>,
+    storeProvider: () -> Store<Event, Effect, State>,
     screenLifecycle: Lifecycle,
     initEventProvider: () -> Event,
 ) : ElmManager<Event, Effect, State> {
 
-    override val store: Store<Event, Effect, State>
-        get() = storeHolder.store
-
-    private val storeHolder: StoreHolder<Event, Effect, State> =
-        storeHolderFactory.invoke(storeCreator)
+    override val store: Store<Event, Effect, State> by fastLazy { storeProvider.invoke() }
 
     @Suppress("LeakingThis", "UnusedPrivateMember")
-    private val storeStarter: ViewBasedStoreStarter<Event, Effect, State> =
+    private val storeStarter: ViewBasedStoreStarter<Event> =
         ViewBasedStoreStarter(
-            storeHolder = storeHolder,
+            storeProvider = { store },
             screenLifecycle = screenLifecycle,
             initEventProvider = initEventProvider,
         )

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
@@ -7,37 +7,33 @@ import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
 fun <Event : Any, Effect : Any, State : Any> Fragment.createElmManager(
+    storeCreator: () -> Store<Event, Effect, State>,
+    initEventProvider: () -> Event,
     storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
         LifecycleAwareStoreHolder(
             lifecycle = lifecycle,
             storeProvider = it,
         )
     },
-    storeCreator: () -> Store<Event, Effect, State>,
-    initEventProvider: () -> Event,
 ): ViewBasedElmManager<Event, Effect, State> =
     ViewBasedElmManager(
-        storeHolderFactory = storeHolderFactory,
-        storeCreator = storeCreator,
+        storeProvider = { storeHolderFactory.invoke { storeCreator.invoke() }.store },
         screenLifecycle = lifecycle,
         initEventProvider = initEventProvider,
-        activityProvider = { requireActivity() },
     )
 
 fun <Event : Any, Effect : Any, State : Any> ComponentActivity.createElmManager(
+    storeCreator: () -> Store<Event, Effect, State>,
+    initEventProvider: () -> Event,
     storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
         LifecycleAwareStoreHolder(
             lifecycle = lifecycle,
             storeProvider = it,
         )
     },
-    storeCreator: () -> Store<Event, Effect, State>,
-    initEventProvider: () -> Event,
 ): ViewBasedElmManager<Event, Effect, State> =
     ViewBasedElmManager(
-        storeHolderFactory = storeHolderFactory,
-        storeCreator = storeCreator,
+        storeProvider = { storeHolderFactory.invoke { storeCreator.invoke() }.store },
         screenLifecycle = lifecycle,
         initEventProvider = initEventProvider,
-        activityProvider = { this },
     )

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
@@ -1,0 +1,43 @@
+package vivid.money.elmslie.android.manager
+
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
+import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.store.Store
+
+fun <Event : Any, Effect : Any, State : Any> Fragment.createElmManager(
+    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
+        LifecycleAwareStoreHolder(
+            lifecycle = lifecycle,
+            storeProvider = it,
+        )
+    },
+    storeCreator: () -> Store<Event, Effect, State>,
+    initEventProvider: () -> Event,
+): ViewBasedElmManager<Event, Effect, State> =
+    ViewBasedElmManager(
+        storeHolderFactory = storeHolderFactory,
+        storeCreator = storeCreator,
+        screenLifecycle = lifecycle,
+        initEventProvider = initEventProvider,
+        activityProvider = { requireActivity() },
+    )
+
+fun <Event : Any, Effect : Any, State : Any> ComponentActivity.createElmManager(
+    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
+        LifecycleAwareStoreHolder(
+            lifecycle = lifecycle,
+            storeProvider = it,
+        )
+    },
+    storeCreator: () -> Store<Event, Effect, State>,
+    initEventProvider: () -> Event,
+): ViewBasedElmManager<Event, Effect, State> =
+    ViewBasedElmManager(
+        storeHolderFactory = storeHolderFactory,
+        storeCreator = storeCreator,
+        screenLifecycle = lifecycle,
+        initEventProvider = initEventProvider,
+        activityProvider = { this },
+    )

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/manager/ViewBasedElmManagerExt.kt
@@ -1,39 +1,53 @@
 package vivid.money.elmslie.android.manager
 
+import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
-import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
-import vivid.money.elmslie.android.storeholder.StoreHolder
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
 import vivid.money.elmslie.core.store.Store
 
-fun <Event : Any, Effect : Any, State : Any> Fragment.createElmManager(
-    storeCreator: () -> Store<Event, Effect, State>,
+fun <
+    Event : Any,
+    Effect : Any,
+    State : Any,
+> Fragment.createElmManager(
+    storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
     initEventProvider: () -> Event,
-    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
-        LifecycleAwareStoreHolder(
-            lifecycle = lifecycle,
-            storeProvider = it,
-        )
-    },
+    key: String,
+    getDefaultArgs: () -> Bundle = { arguments ?: Bundle() },
+    getViewModelStoreOwner: () -> ViewModelStoreOwner = { this },
+    getSavedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
 ): ViewBasedElmManager<Event, Effect, State> =
     ViewBasedElmManager(
-        storeProvider = { storeHolderFactory.invoke { storeCreator.invoke() }.store },
+        storeFactory = storeFactory,
         screenLifecycle = lifecycle,
         initEventProvider = initEventProvider,
+        key = key,
+        getViewModelStoreOwner = getViewModelStoreOwner,
+        getSavedStateRegistryOwner = getSavedStateRegistryOwner,
+        getDefaultArgs = getDefaultArgs,
     )
 
-fun <Event : Any, Effect : Any, State : Any> ComponentActivity.createElmManager(
-    storeCreator: () -> Store<Event, Effect, State>,
+fun <
+    Event : Any,
+    Effect : Any,
+    State : Any,
+> ComponentActivity.createElmManager(
+    storeFactory: (SavedStateHandle) -> Store<Event, Effect, State>,
     initEventProvider: () -> Event,
-    storeHolderFactory: (() -> Store<Event, Effect, State>) -> StoreHolder<Event, Effect, State> = {
-        LifecycleAwareStoreHolder(
-            lifecycle = lifecycle,
-            storeProvider = it,
-        )
-    },
+    key: String,
+    getDefaultArgs: () -> Bundle = { this.intent?.extras ?: Bundle() },
+    getViewModelStoreOwner: () -> ViewModelStoreOwner = { this },
+    getSavedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
 ): ViewBasedElmManager<Event, Effect, State> =
     ViewBasedElmManager(
-        storeProvider = { storeHolderFactory.invoke { storeCreator.invoke() }.store },
+        storeFactory = storeFactory,
         screenLifecycle = lifecycle,
         initEventProvider = initEventProvider,
+        key = key,
+        getViewModelStoreOwner = getViewModelStoreOwner,
+        getSavedStateRegistryOwner = getSavedStateRegistryOwner,
+        getDefaultArgs = getDefaultArgs,
     )

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeath.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/processdeath/StopElmOnProcessDeath.kt
@@ -1,3 +1,0 @@
-package vivid.money.elmslie.android.processdeath
-
-interface StopElmOnProcessDeath

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -1,0 +1,81 @@
+package vivid.money.elmslie.android.renderer
+
+import androidx.lifecycle.*
+import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.Lifecycle.State.STARTED
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import vivid.money.elmslie.core.config.ElmslieConfig
+
+class ElmRenderer<Effect : Any, State : Any>(
+    private val delegate: ElmRendererDelegate<Effect, State>,
+    private val screenLifecycle: Lifecycle,
+) {
+
+    val store
+        get() = delegate.storeHolder.store
+
+    private val logger = ElmslieConfig.logger
+    private val ioDispatcher: CoroutineDispatcher = ElmslieConfig.ioDispatchers
+    private val canRender
+        get() = screenLifecycle.currentState.isAtLeast(STARTED)
+
+    init {
+        with(screenLifecycle) {
+            coroutineScope.launch {
+                store
+                    .effects()
+                    .flowWithLifecycle(
+                        lifecycle = screenLifecycle,
+                        minActiveState = RESUMED,
+                    )
+                    .collect { effect -> catchEffectErrors { delegate.handleEffect(effect) } }
+            }
+            coroutineScope.launch {
+                store
+                    .states()
+                    .flowWithLifecycle(
+                        lifecycle = screenLifecycle,
+                        minActiveState = STARTED,
+                    )
+                    .map { state ->
+                        val list = mapListItems(state)
+                        state to list
+                    }
+                    .catch { logger.fatal("Crash while mapping state", it) }
+                    .flowOn(ioDispatcher)
+                    .collect { (state, listItems) ->
+                        catchStateErrors {
+                            if (canRender) {
+                                delegate.renderList(state, listItems)
+                                delegate.render(state)
+                            }
+                        }
+                    }
+            }
+        }
+    }
+
+    private fun mapListItems(state: State) =
+        catchStateErrors { delegate.mapList(state) } ?: emptyList()
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun <T> catchStateErrors(action: () -> T?) =
+        try {
+            action()
+        } catch (t: Throwable) {
+            logger.fatal("Crash while rendering state", t)
+            null
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun <T> catchEffectErrors(action: () -> T?) =
+        try {
+            action()
+        } catch (t: Throwable) {
+            logger.fatal("Crash while handling effect", t)
+        }
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.config.ElmslieConfig
 
 class ElmRenderer<Effect : Any, State : Any>(
@@ -15,9 +16,7 @@ class ElmRenderer<Effect : Any, State : Any>(
     private val screenLifecycle: Lifecycle,
 ) {
 
-    val store
-        get() = delegate.storeHolder.store
-
+    private val store by fastLazy { delegate.store }
     private val logger = ElmslieConfig.logger
     private val ioDispatcher: CoroutineDispatcher = ElmslieConfig.ioDispatchers
     private val canRender

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
@@ -1,0 +1,12 @@
+package vivid.money.elmslie.android.renderer
+
+import vivid.money.elmslie.android.storeholder.StoreHolder
+
+interface ElmRendererDelegate<Effect : Any, State : Any> {
+    val storeHolder: StoreHolder<*, Effect, State>
+
+    fun render(state: State)
+    fun handleEffect(effect: Effect): Unit? = Unit
+    fun mapList(state: State): List<Any> = emptyList()
+    fun renderList(state: State, list: List<Any>) {}
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
@@ -1,9 +1,9 @@
 package vivid.money.elmslie.android.renderer
 
-import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.store.Store
 
 interface ElmRendererDelegate<Effect : Any, State : Any> {
-    val storeHolder: StoreHolder<*, Effect, State>
+    val store: Store<*, Effect, State>
 
     fun render(state: State)
     fun handleEffect(effect: Effect): Unit? = Unit

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
@@ -1,21 +1,11 @@
 package vivid.money.elmslie.android.screen
 
+import vivid.money.elmslie.android.storeholder.ElmCreatorDelegate
+import vivid.money.elmslie.android.renderer.ElmRendererDelegate
 import vivid.money.elmslie.android.storeholder.StoreHolder
-import vivid.money.elmslie.core.store.Store
 
-/**
- * Required part of ELM implementation for each fragment
- */
-interface ElmDelegate<Event : Any, Effect : Any, State : Any> {
-
+interface ElmDelegate<Event : Any, Effect : Any, State : Any> :
+    ElmRendererDelegate<Effect, State>, ElmCreatorDelegate<Event, Effect, State> {
     val initEvent: Event
-    val storeHolder: StoreHolder<Event, Effect, State>
-
-    @Deprecated("Use storeHolder property instead")
-    fun createStore(): Store<Event, Effect, State>? = null
-    fun render(state: State)
-    fun handleEffect(effect: Effect): Unit? = Unit
-
-    fun mapList(state: State): List<Any> = emptyList()
-    fun renderList(state: State, list: List<Any>) {}
+    override val storeHolder: StoreHolder<Event, Effect, State>
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmDelegate.kt
@@ -1,11 +1,10 @@
 package vivid.money.elmslie.android.screen
 
-import vivid.money.elmslie.android.storeholder.ElmCreatorDelegate
 import vivid.money.elmslie.android.renderer.ElmRendererDelegate
-import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.store.Store
 
-interface ElmDelegate<Event : Any, Effect : Any, State : Any> :
-    ElmRendererDelegate<Effect, State>, ElmCreatorDelegate<Event, Effect, State> {
+interface ElmDelegate<Event : Any, Effect : Any, State : Any> : ElmRendererDelegate<Effect, State> {
+    override val store: Store<Event, Effect, State>
+
     val initEvent: Event
-    override val storeHolder: StoreHolder<Event, Effect, State>
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -1,6 +1,5 @@
 package vivid.money.elmslie.android.screen
 
-import android.app.Activity
 import androidx.lifecycle.*
 import vivid.money.elmslie.android.renderer.ElmRenderer
 import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
@@ -8,7 +7,6 @@ import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
 class ElmScreen<Event : Any, Effect : Any, State : Any>(
     delegate: ElmDelegate<Event, Effect, State>,
     screenLifecycle: Lifecycle,
-    activityProvider: () -> Activity,
 ) {
 
     @Suppress("LeakingThis", "UnusedPrivateMember")
@@ -24,6 +22,5 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
             storeHolder = delegate.storeHolder,
             screenLifecycle = screenLifecycle,
             initEventProvider = { delegate.initEvent },
-            activityProvider = activityProvider,
         )
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -5,7 +5,7 @@ import vivid.money.elmslie.android.renderer.ElmRenderer
 import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
 
 class ElmScreen<Event : Any, Effect : Any, State : Any>(
-    delegate: ElmDelegate<Event, Effect, State>,
+    private val delegate: ElmDelegate<Event, Effect, State>,
     screenLifecycle: Lifecycle,
 ) {
 
@@ -19,7 +19,7 @@ class ElmScreen<Event : Any, Effect : Any, State : Any>(
     @Suppress("LeakingThis", "UnusedPrivateMember")
     private val elmStarter =
         ViewBasedStoreStarter(
-            storeHolder = delegate.storeHolder,
+            storeProvider = { delegate.store },
             screenLifecycle = screenLifecycle,
             initEventProvider = { delegate.initEvent },
         )

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/screen/ElmScreen.kt
@@ -2,102 +2,28 @@ package vivid.money.elmslie.android.screen
 
 import android.app.Activity
 import androidx.lifecycle.*
-import androidx.lifecycle.Lifecycle.State.RESUMED
-import androidx.lifecycle.Lifecycle.State.STARTED
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
-import vivid.money.elmslie.android.processdeath.ProcessDeathDetector.isRestoringAfterProcessDeath
-import vivid.money.elmslie.android.processdeath.StopElmOnProcessDeath
-import vivid.money.elmslie.core.config.ElmslieConfig
+import vivid.money.elmslie.android.renderer.ElmRenderer
+import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
 
 class ElmScreen<Event : Any, Effect : Any, State : Any>(
-    private val delegate: ElmDelegate<Event, Effect, State>,
-    private val screenLifecycle: Lifecycle,
-    private val activityProvider: () -> Activity,
+    delegate: ElmDelegate<Event, Effect, State>,
+    screenLifecycle: Lifecycle,
+    activityProvider: () -> Activity,
 ) {
 
-    val store
-        get() = delegate.storeHolder.store
+    @Suppress("LeakingThis", "UnusedPrivateMember")
+    private val elmRenderer =
+        ElmRenderer(
+            delegate = delegate,
+            screenLifecycle = screenLifecycle,
+        )
 
-    private val logger = ElmslieConfig.logger
-    private val ioDispatcher: CoroutineDispatcher = ElmslieConfig.ioDispatchers
-    private var isAfterProcessDeath = false
-    private val canRender
-        get() = screenLifecycle.currentState.isAtLeast(STARTED)
-
-    init {
-        with(screenLifecycle) {
-            coroutineScope.launchWhenCreated {
-                saveProcessDeathState()
-                triggerInitEventIfNecessary()
-            }
-            coroutineScope.launch {
-                store
-                    .effects()
-                    .flowWithLifecycle(
-                        lifecycle = screenLifecycle,
-                        minActiveState = RESUMED,
-                    )
-                    .collect { effect -> catchEffectErrors { delegate.handleEffect(effect) } }
-            }
-            coroutineScope.launch {
-                store
-                    .states()
-                    .flowWithLifecycle(
-                        lifecycle = screenLifecycle,
-                        minActiveState = STARTED,
-                    )
-                    .map { state ->
-                        val list = mapListItems(state)
-                        state to list
-                    }
-                    .catch { logger.fatal("Crash while mapping state", it) }
-                    .flowOn(ioDispatcher)
-                    .collect { (state, listItems) ->
-                        catchStateErrors {
-                            if (canRender) {
-                                delegate.renderList(state, listItems)
-                                delegate.render(state)
-                            }
-                        }
-                    }
-            }
-        }
-    }
-
-    private fun mapListItems(state: State) =
-        catchStateErrors { delegate.mapList(state) } ?: emptyList()
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun <T> catchStateErrors(action: () -> T?) =
-        try {
-            action()
-        } catch (t: Throwable) {
-            logger.fatal("Crash while rendering state", t)
-            null
-        }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun <T> catchEffectErrors(action: () -> T?) =
-        try {
-            action()
-        } catch (t: Throwable) {
-            logger.fatal("Crash while handling effect", t)
-        }
-
-    private fun saveProcessDeathState() {
-        isAfterProcessDeath = isRestoringAfterProcessDeath
-    }
-
-    private fun triggerInitEventIfNecessary() {
-        if (!delegate.storeHolder.isStarted && isAllowedToRun()) {
-            store.accept(delegate.initEvent)
-        }
-    }
-
-    private fun isAllowedToRun() =
-        !isAfterProcessDeath || activityProvider() !is StopElmOnProcessDeath
+    @Suppress("LeakingThis", "UnusedPrivateMember")
+    private val elmStarter =
+        ViewBasedStoreStarter(
+            storeHolder = delegate.storeHolder,
+            screenLifecycle = screenLifecycle,
+            initEventProvider = { delegate.initEvent },
+            activityProvider = activityProvider,
+        )
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/ElmCreatorDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/ElmCreatorDelegate.kt
@@ -1,0 +1,10 @@
+package vivid.money.elmslie.android.storeholder
+
+import vivid.money.elmslie.core.store.Store
+
+interface ElmCreatorDelegate<Event : Any, Effect : Any, State : Any> {
+    fun createStore(): Store<Event, Effect, State>
+    fun createStoreHolder(
+        storeProvider: () -> Store<Event, Effect, State>
+    ): StoreHolder<Event, Effect, State>
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/LifecycleAwareStoreHolder.kt
@@ -9,15 +9,14 @@ class LifecycleAwareStoreHolder<Event : Any, Effect : Any, State : Any>(
     storeProvider: () -> Store<Event, Effect, State>,
 ) : StoreHolder<Event, Effect, State> {
 
-    override var isStarted = false
+    override val store by fastLazy { storeProvider().start() }
 
-    override val store by fastLazy { storeProvider().start().also { isStarted = true } }
-
-    private val lifecycleObserver = object : DefaultLifecycleObserver {
-        override fun onDestroy(owner: LifecycleOwner) {
-            store.stop()
+    private val lifecycleObserver =
+        object : DefaultLifecycleObserver {
+            override fun onDestroy(owner: LifecycleOwner) {
+                store.stop()
+            }
         }
-    }
 
     init {
         lifecycle.addObserver(lifecycleObserver)

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storeholder/StoreHolder.kt
@@ -4,12 +4,10 @@ import vivid.money.elmslie.core.store.Store
 
 /**
  * Implementation of this interface should:
- *  1. call Store::start during store creation
- *  2. guarantee invariance of store while the view exists
- *  3. call Store::stop when store be ready to gc
- **/
+ * 1. call Store::start during store creation
+ * 2. guarantee invariance of store while the view exists
+ * 3. call Store::stop when store be ready to gc
+ */
 interface StoreHolder<Event : Any, Effect : Any, State : Any> {
-
-    val isStarted: Boolean
     val store: Store<Event, Effect, State>
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
@@ -1,0 +1,38 @@
+package vivid.money.elmslie.android.storestarter
+
+import android.app.Activity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import vivid.money.elmslie.android.processdeath.ProcessDeathDetector
+import vivid.money.elmslie.android.processdeath.StopElmOnProcessDeath
+import vivid.money.elmslie.android.storeholder.StoreHolder
+
+class ViewBasedStoreStarter<Event : Any, Effect : Any, State : Any>(
+    private val storeHolder: StoreHolder<Event, Effect, State>,
+    screenLifecycle: Lifecycle,
+    private val initEventProvider: () -> Event,
+    private val activityProvider: () -> Activity,
+) {
+
+    private var isAfterProcessDeath = false
+
+    init {
+        screenLifecycle.coroutineScope.launchWhenCreated {
+            saveProcessDeathState()
+            triggerInitEventIfNecessary()
+        }
+    }
+
+    private fun saveProcessDeathState() {
+        isAfterProcessDeath = ProcessDeathDetector.isRestoringAfterProcessDeath
+    }
+
+    private fun triggerInitEventIfNecessary() {
+        if (!storeHolder.isStarted && isAllowedToRun()) {
+            storeHolder.store.accept(initEventProvider.invoke())
+        }
+    }
+
+    private fun isAllowedToRun() =
+        !isAfterProcessDeath || activityProvider() !is StopElmOnProcessDeath
+}

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
@@ -1,17 +1,15 @@
 package vivid.money.elmslie.android.storestarter
 
-import android.app.Activity
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import vivid.money.elmslie.android.processdeath.ProcessDeathDetector
-import vivid.money.elmslie.android.processdeath.StopElmOnProcessDeath
 import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.core.config.ElmslieConfig
 
 class ViewBasedStoreStarter<Event : Any, Effect : Any, State : Any>(
     private val storeHolder: StoreHolder<Event, Effect, State>,
     screenLifecycle: Lifecycle,
     private val initEventProvider: () -> Event,
-    private val activityProvider: () -> Activity,
 ) {
 
     private var isAfterProcessDeath = false
@@ -34,5 +32,5 @@ class ViewBasedStoreStarter<Event : Any, Effect : Any, State : Any>(
     }
 
     private fun isAllowedToRun() =
-        !isAfterProcessDeath || activityProvider() !is StopElmOnProcessDeath
+        !isAfterProcessDeath || !ElmslieConfig.shouldStopElmOnProcessDeath
 }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
@@ -3,16 +3,20 @@ package vivid.money.elmslie.android.storestarter
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.coroutineScope
 import vivid.money.elmslie.android.processdeath.ProcessDeathDetector
-import vivid.money.elmslie.android.storeholder.StoreHolder
+import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.config.ElmslieConfig
+import vivid.money.elmslie.core.store.Store
 
-class ViewBasedStoreStarter<Event : Any, Effect : Any, State : Any>(
-    private val storeHolder: StoreHolder<Event, Effect, State>,
+class ViewBasedStoreStarter<Event : Any>(
+    private val storeProvider: () -> Store<Event, *, *>,
     screenLifecycle: Lifecycle,
     private val initEventProvider: () -> Event,
 ) {
 
     private var isAfterProcessDeath = false
+    private val store by fastLazy {
+        storeProvider.invoke()
+    }
 
     init {
         screenLifecycle.coroutineScope.launchWhenCreated {
@@ -26,8 +30,8 @@ class ViewBasedStoreStarter<Event : Any, Effect : Any, State : Any>(
     }
 
     private fun triggerInitEventIfNecessary() {
-        if (!storeHolder.isStarted && isAllowedToRun()) {
-            storeHolder.store.accept(initEventProvider.invoke())
+        if (!store.isStarted && isAllowedToRun()) {
+            store.accept(initEventProvider.invoke())
         }
     }
 

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/storestarter/ViewBasedStoreStarter.kt
@@ -7,6 +7,7 @@ import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.config.ElmslieConfig
 import vivid.money.elmslie.core.store.Store
 
+//TODO: think about renaming it to something with InitEvents
 class ViewBasedStoreStarter<Event : Any>(
     private val storeProvider: () -> Store<Event, *, *>,
     screenLifecycle: Lifecycle,

--- a/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentActivity.kt
+++ b/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentActivity.kt
@@ -2,9 +2,8 @@ package vivid.money.elmslie.compose
 
 import androidx.activity.ComponentActivity
 import androidx.annotation.LayoutRes
+import androidx.lifecycle.SavedStateHandle
 import vivid.money.elmslie.android.manager.createElmManager
-import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
-import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
 abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> : ComponentActivity {
@@ -16,22 +15,14 @@ abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> : Co
     @Suppress("LeakingThis", "UnusedPrivateMember")
     private val elmManager =
         createElmManager(
-            storeHolderFactory = ::createStoreHolder,
-            storeCreator = ::createStore,
+            storeFactory = ::createStore,
             initEventProvider = { initEvent },
+            key = this::class.java.name,
         )
 
     protected val store
         get() = elmManager.store
 
-    open fun createStoreHolder(
-        storeProvider: () -> Store<Event, Effect, State>
-    ): StoreHolder<Event, Effect, State> =
-        LifecycleAwareStoreHolder(
-            lifecycle = lifecycle,
-            storeProvider = storeProvider,
-        )
-
     abstract val initEvent: Event
-    abstract fun createStore(): Store<Event, Effect, State>
+    abstract fun createStore(stateHandle: SavedStateHandle): Store<Event, Effect, State>
 }

--- a/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentActivity.kt
+++ b/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentActivity.kt
@@ -3,13 +3,11 @@ package vivid.money.elmslie.compose
 import androidx.activity.ComponentActivity
 import androidx.annotation.LayoutRes
 import vivid.money.elmslie.android.manager.createElmManager
-import vivid.money.elmslie.android.storeholder.ElmCreatorDelegate
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
-abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> :
-    ComponentActivity, ElmCreatorDelegate<Event, Effect, State> {
+abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> : ComponentActivity {
 
     constructor() : super()
 
@@ -26,7 +24,7 @@ abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> :
     protected val store
         get() = elmManager.store
 
-    override fun createStoreHolder(
+    open fun createStoreHolder(
         storeProvider: () -> Store<Event, Effect, State>
     ): StoreHolder<Event, Effect, State> =
         LifecycleAwareStoreHolder(
@@ -35,4 +33,5 @@ abstract class ElmComponentActivity<Event : Any, Effect : Any, State : Any> :
         )
 
     abstract val initEvent: Event
+    abstract fun createStore(): Store<Event, Effect, State>
 }

--- a/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
+++ b/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
@@ -3,13 +3,11 @@ package vivid.money.elmslie.compose
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import vivid.money.elmslie.android.manager.createElmManager
-import vivid.money.elmslie.android.storeholder.ElmCreatorDelegate
 import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
 import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
-abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> :
-    Fragment, ElmCreatorDelegate<Event, Effect, State> {
+abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> : Fragment {
 
     constructor() : super()
 
@@ -26,7 +24,7 @@ abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> :
     protected val store
         get() = elmManager.store
 
-    override fun createStoreHolder(
+    open fun createStoreHolder(
         storeProvider: () -> Store<Event, Effect, State>
     ): StoreHolder<Event, Effect, State> =
         LifecycleAwareStoreHolder(
@@ -35,4 +33,5 @@ abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> :
         )
 
     abstract val initEvent: Event
+    abstract fun createStore(): Store<Event, Effect, State>
 }

--- a/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
+++ b/elmslie-compose/src/main/java/vivid/money/elmslie/compose/ElmComponentFragment.kt
@@ -2,9 +2,9 @@ package vivid.money.elmslie.compose
 
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.SavedStateHandle
+import vivid.money.elmslie.android.manager.ElmManager
 import vivid.money.elmslie.android.manager.createElmManager
-import vivid.money.elmslie.android.storeholder.LifecycleAwareStoreHolder
-import vivid.money.elmslie.android.storeholder.StoreHolder
 import vivid.money.elmslie.core.store.Store
 
 abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> : Fragment {
@@ -14,24 +14,16 @@ abstract class ElmComponentFragment<Event : Any, Effect : Any, State : Any> : Fr
     constructor(@LayoutRes contentLayoutId: Int) : super(contentLayoutId)
 
     @Suppress("LeakingThis", "UnusedPrivateMember")
-    private val elmManager =
+    private val elmManager: ElmManager<Event, Effect, State> =
         createElmManager(
-            storeHolderFactory = ::createStoreHolder,
-            storeCreator = ::createStore,
+            storeFactory = ::createStore,
             initEventProvider = { initEvent },
+            key = this::class.java.name,
         )
 
     protected val store
         get() = elmManager.store
 
-    open fun createStoreHolder(
-        storeProvider: () -> Store<Event, Effect, State>
-    ): StoreHolder<Event, Effect, State> =
-        LifecycleAwareStoreHolder(
-            lifecycle = lifecycle,
-            storeProvider = storeProvider,
-        )
-
     abstract val initEvent: Event
-    abstract fun createStore(): Store<Event, Effect, State>
+    abstract fun createStore(stateHandle: SavedStateHandle): Store<Event, Effect, State>
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
@@ -18,6 +18,8 @@ object ElmslieConfig {
 
     @Volatile private lateinit var _ioDispatchers: CoroutineDispatcher
 
+    @Volatile private var _shouldStopElmOnProcessDeath: Boolean = true
+
     val logger: ElmslieLogger
         get() = _logger
 
@@ -26,6 +28,9 @@ object ElmslieConfig {
 
     val ioDispatchers: CoroutineDispatcher
         get() = _ioDispatchers
+
+    val shouldStopElmOnProcessDeath: Boolean
+        get() = _shouldStopElmOnProcessDeath
 
     init {
         logger { always(IgnoreLog) }
@@ -67,5 +72,9 @@ object ElmslieConfig {
      */
     fun ioDispatchers(builder: () -> CoroutineDispatcher) {
         _ioDispatchers = builder()
+    }
+
+    fun shouldStopElmOnProcessDeath(builder: () -> Boolean) {
+        _shouldStopElmOnProcessDeath = builder()
     }
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -45,6 +45,12 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
 
     override fun effects(): Flow<Effect> = effectsFlow.asSharedFlow()
 
+    override fun launch(block: suspend () -> Unit) {
+        storeScope.launch {
+            block.invoke()
+        }
+    }
+
     private fun dispatchEvent(event: Event) {
         storeScope.launch {
             try {

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
@@ -43,4 +43,9 @@ interface Store<Event, Effect, State> {
      * By default, [Effect] is collected in [Dispatchers.IO].
      */
     fun effects(): Flow<Effect>
+
+    /**
+     * TODO: add notes
+     */
+    fun launch(block: suspend () -> Unit)
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
@@ -1,0 +1,69 @@
+package vivid.money.elmslie.core.store.linking
+
+import vivid.money.elmslie.core.store.Store
+
+fun <
+    ParentEvent : Any,
+    ParentState : Any,
+    ParentEffect : Any,
+    ChildEvent : Any,
+    ChildState : Any,
+    ChildEffect : Any,
+> Store<ParentEvent, ParentState, ParentEffect>.linkTo(
+    childStore: Store<ChildEvent, ChildEffect, ChildState>,
+    effectMapper: (ChildEffect) -> ParentEvent?,
+    stateMapper: (ChildState) -> ParentEvent?,
+) = apply {
+    launch {
+        childStore.states().collect { stateMapper.invoke(it)?.let(this@linkTo::accept) }
+        childStore.effects().collect { effectMapper.invoke(it)?.let(this@linkTo::accept) }
+    }
+}
+
+fun <
+    ParentEvent : Any,
+    ParentState : Any,
+    ParentEffect : Any,
+    ChildEvent : Any,
+    ChildState : Any,
+    ChildEffect : Any,
+> Store<ParentEvent, ParentState, ParentEffect>.linkTo(
+    childStore: Store<ChildEvent, ChildEffect, ChildState>,
+    effectMapper: (ChildState, ChildEffect) -> ParentEvent? = { _, _ -> null },
+    stateMapper: (ChildState, ChildState) -> ParentEvent? = { _, _ -> null },
+) = apply {
+    launch {
+        var currentState = childStore.currentState
+        childStore.states().collect {
+            stateMapper.invoke(currentState, it)?.let(this@linkTo::accept)
+            currentState = it
+        }
+        childStore.effects().collect {
+            effectMapper.invoke(currentState, it)?.let(this@linkTo::accept)
+        }
+    }
+}
+
+fun <
+    ParentEvent : Any,
+    ParentState : Any,
+    ParentEffect : Any,
+    ChildEvent : Any,
+    ChildState : Any,
+    ChildEffect : Any,
+> Store<ParentEvent, ParentState, ParentEffect>.linkListTo(
+    childStore: Store<ChildEvent, ChildEffect, ChildState>,
+    effectMapper: (ChildState, ChildEffect) -> List<ParentEvent> = { _, _ -> emptyList() },
+    stateMapper: (ChildState, ChildState) -> List<ParentEvent> = { _, _ -> emptyList() },
+) = apply {
+    launch {
+        var currentState = childStore.currentState
+        childStore.states().collect {
+            stateMapper.invoke(currentState, it).forEach(this@linkListTo::accept)
+            currentState = it
+        }
+        childStore.effects().collect {
+            effectMapper.invoke(currentState, it).forEach(this@linkListTo::accept)
+        }
+    }
+}

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
@@ -2,6 +2,7 @@ package vivid.money.elmslie.core.store.linking
 
 import vivid.money.elmslie.core.store.Store
 
+//TODO: think about reusing one function
 fun <
     ParentEvent : Any,
     ParentState : Any,
@@ -30,12 +31,14 @@ fun <
     effectMapper: (ChildState, ChildEffect) -> ParentEvent? = { _, _ -> null },
     stateMapper: (ChildState, ChildState) -> ParentEvent? = { _, _ -> null },
 ): Store<ParentEvent, ParentState, ParentEffect> = apply {
+    var currentState = childStore.currentState
     launch {
-        var currentState = childStore.currentState
         childStore.states().collect {
             stateMapper.invoke(currentState, it)?.let(this@linkTo::accept)
             currentState = it
         }
+    }
+    launch {
         childStore.effects().collect {
             effectMapper.invoke(currentState, it)?.let(this@linkTo::accept)
         }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
@@ -2,6 +2,7 @@ package vivid.money.elmslie.core.store.linking
 
 import vivid.money.elmslie.core.store.Store
 
+// TODO: think about invoking one function from another
 fun <
     ParentEvent : Any,
     ParentState : Any,

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
@@ -15,10 +15,8 @@ fun <
     effectMapper: (ChildEffect) -> ParentEvent?,
     stateMapper: (ChildState) -> ParentEvent?,
 ) = apply {
-    launch {
-        childStore.states().collect { stateMapper.invoke(it)?.let(this@linkTo::accept) }
-        childStore.effects().collect { effectMapper.invoke(it)?.let(this@linkTo::accept) }
-    }
+    launch { childStore.states().collect { stateMapper.invoke(it)?.let(this@linkTo::accept) } }
+    launch { childStore.effects().collect { effectMapper.invoke(it)?.let(this@linkTo::accept) } }
 }
 
 fun <
@@ -57,12 +55,14 @@ fun <
     effectMapper: (ChildState, ChildEffect) -> List<ParentEvent> = { _, _ -> emptyList() },
     stateMapper: (ChildState, ChildState) -> List<ParentEvent> = { _, _ -> emptyList() },
 ) = apply {
+    var currentState = childStore.currentState
     launch {
-        var currentState = childStore.currentState
         childStore.states().collect {
             stateMapper.invoke(currentState, it).forEach(this@linkListTo::accept)
             currentState = it
         }
+    }
+    launch {
         childStore.effects().collect {
             effectMapper.invoke(currentState, it).forEach(this@linkListTo::accept)
         }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/linking/LinkingExt.kt
@@ -2,7 +2,6 @@ package vivid.money.elmslie.core.store.linking
 
 import vivid.money.elmslie.core.store.Store
 
-// TODO: think about invoking one function from another
 fun <
     ParentEvent : Any,
     ParentState : Any,
@@ -14,7 +13,7 @@ fun <
     childStore: Store<ChildEvent, ChildEffect, ChildState>,
     effectMapper: (ChildEffect) -> ParentEvent?,
     stateMapper: (ChildState) -> ParentEvent?,
-) = apply {
+): Store<ParentEvent, ParentState, ParentEffect> = apply {
     launch { childStore.states().collect { stateMapper.invoke(it)?.let(this@linkTo::accept) } }
     launch { childStore.effects().collect { effectMapper.invoke(it)?.let(this@linkTo::accept) } }
 }
@@ -30,7 +29,7 @@ fun <
     childStore: Store<ChildEvent, ChildEffect, ChildState>,
     effectMapper: (ChildState, ChildEffect) -> ParentEvent? = { _, _ -> null },
     stateMapper: (ChildState, ChildState) -> ParentEvent? = { _, _ -> null },
-) = apply {
+): Store<ParentEvent, ParentState, ParentEffect> = apply {
     launch {
         var currentState = childStore.currentState
         childStore.states().collect {
@@ -54,7 +53,7 @@ fun <
     childStore: Store<ChildEvent, ChildEffect, ChildState>,
     effectMapper: (ChildState, ChildEffect) -> List<ParentEvent> = { _, _ -> emptyList() },
     stateMapper: (ChildState, ChildState) -> List<ParentEvent> = { _, _ -> emptyList() },
-) = apply {
+): Store<ParentEvent, ParentState, ParentEffect> = apply {
     var currentState = childStore.currentState
     launch {
         childStore.states().collect {


### PR DESCRIPTION
It's a draft.

The main idea is to allow to create of more than one store inside a fragment (or compose function) and create a one-direction connect btw them (linkTo). It allows mapping state changes and effects of one store to events of another store. Communication in another direction can be implemented inside application (inside actors or reducers) and work on this is still in progress.