### PR TITLE
execute commands on IO dispatcher

### DIFF
--- a/elmslie-coroutines/src/main/java/vivid/money/elmslie/coroutines/ElmStoreCompat.kt
+++ b/elmslie-coroutines/src/main/java/vivid/money/elmslie/coroutines/ElmStoreCompat.kt
@@ -1,11 +1,14 @@
 package vivid.money.elmslie.coroutines
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOn
-import vivid.money.elmslie.core.config.ElmslieConfig
+import kotlinx.coroutines.launch
 import vivid.money.elmslie.core.disposable.Disposable
 import vivid.money.elmslie.core.store.DefaultActor
 import vivid.money.elmslie.core.store.StateReducer
@@ -28,10 +31,10 @@ class ElmStoreCompat<Event : Any, State : Any, Effect : Any, Command : Any>(
 @Suppress("TooGenericExceptionCaught", "RethrowCaughtException")
 private fun <Command : Any, Event : Any> Actor<Command, Event>.toActor() =
     DefaultActor<Command, Event> { command, onEvent, onError ->
-        val job = GlobalScope.launch(Dispatchers.Unconfined) {
+        val job = GlobalScope.launch(Unconfined) {
             try {
                 execute(command)
-                    .flowOn(ElmslieConfig.backgroundExecutor.asCoroutineDispatcher())
+                    .flowOn(IO)
                     .collect { event -> onEvent(event) }
             } catch (t: CancellationException) {
                 throw t


### PR DESCRIPTION
also, concurrent state modification is broken...
if 2 events arrive at the same time and we have non-single-thread scheduled executor set as our background executor — we'll lose one of the states due to race condition