### PR TITLE
fix Switcher + rewrite one example

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -25,6 +25,10 @@ class ElmRenderer<Effect : Any, State : Any>(
     init {
         with(screenLifecycle) {
             coroutineScope.launch {
+                /**
+                 * [whenCreated] lambda is needed because we can't access to store before [Lifecycle.STARTED]
+                 * otherwise it crashes.
+                 */
                 whenCreated {
                     store
                         .effects()

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/switcher/Switcher.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/switcher/Switcher.kt
@@ -2,8 +2,7 @@ package vivid.money.elmslie.core.switcher
 
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import vivid.money.elmslie.core.store.DefaultActor
@@ -46,7 +45,10 @@ class Switcher {
 
             delay(delayMillis)
 
-            action.invoke().collect { send(it) }
+            action.invoke()
+                .onEach { send(it) }
+                .catch { close(it) }
+                .collect()
 
             channel.close()
         }

--- a/elmslie-samples/coroutines-loader/build.gradle
+++ b/elmslie-samples/coroutines-loader/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     implementation(deps.android.appcompat)
     implementation(deps.android.material)
+    implementation(deps.android.fragmentKtx)
     implementation(deps.coroutines.core)
 
     testImplementation(project(":elmslie-test"))

--- a/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainActivity.kt
+++ b/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainActivity.kt
@@ -1,66 +1,20 @@
 package vivid.money.elmslie.samples.coroutines.timer
 
-import android.annotation.SuppressLint
 import android.os.Bundle
-import android.view.View.GONE
-import android.view.View.VISIBLE
-import android.widget.Button
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.SavedStateHandle
-import com.google.android.material.snackbar.Snackbar
-import vivid.money.elmslie.android.elmStore
-import vivid.money.elmslie.android.renderer.ElmRenderer
-import vivid.money.elmslie.android.renderer.ElmRendererDelegate
-import vivid.money.elmslie.android.storestarter.ViewBasedStoreStarter
-import vivid.money.elmslie.samples.coroutines.timer.elm.Effect
-import vivid.money.elmslie.samples.coroutines.timer.elm.Event
-import vivid.money.elmslie.samples.coroutines.timer.elm.State
-import vivid.money.elmslie.samples.coroutines.timer.elm.storeFactory
+import androidx.fragment.app.commit
+import kotlin.random.Random
 
-internal class MainActivity : AppCompatActivity(R.layout.activity_main),
-    ElmRendererDelegate<Effect, State> {
+internal class MainActivity : AppCompatActivity(R.layout.activity_main) {
 
-    override val store by elmStore(
-        storeFactory = ::createStore,
-    )
-
-    @Suppress("LeakingThis")
-    private val renderer =
-        ElmRenderer(
-            delegate = this,
-            screenLifecycle = lifecycle,
-        )
-
-    @Suppress("LeakingThis", "UnusedPrivateMember")
-    private val starter =
-        ViewBasedStoreStarter(
-            storeProvider = { store },
-            screenLifecycle = lifecycle,
-            initEventProvider = { Event.Init },
-        )
-
+    @Suppress("MagicNumber")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        findViewById<Button>(R.id.start).setOnClickListener { store.accept(Event.Start) }
-        findViewById<Button>(R.id.stop).setOnClickListener { store.accept(Event.Stop) }
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                val screenId = Random.nextInt(100).toString()
+                replace(R.id.container, MainFragment.newInstance(screenId))
+            }
+        }
     }
-
-    @SuppressLint("SetTextI18n")
-    override fun render(state: State) {
-        findViewById<TextView>(R.id.start).visibility = if (state.isStarted) GONE else VISIBLE
-        findViewById<TextView>(R.id.stop).visibility = if (state.isStarted) VISIBLE else GONE
-        findViewById<TextView>(R.id.currentValue).text = "Seconds passed: ${state.secondsPassed}"
-    }
-
-    override fun handleEffect(effect: Effect) = when (effect) {
-        is Effect.Error -> Snackbar.make(
-            findViewById(R.id.content),
-            "Error!",
-            Snackbar.LENGTH_SHORT
-        ).show()
-    }
-
-    @Suppress("UnusedPrivateMember")
-    private fun createStore(savedStateHandle: SavedStateHandle) = storeFactory()
 }

--- a/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainFragment.kt
+++ b/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainFragment.kt
@@ -1,0 +1,78 @@
+package vivid.money.elmslie.samples.coroutines.timer
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.View
+import android.view.View.GONE
+import android.view.View.VISIBLE
+import android.widget.Button
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.google.android.material.snackbar.Snackbar
+import vivid.money.elmslie.android.elmStore
+import vivid.money.elmslie.android.renderer.ElmRenderer
+import vivid.money.elmslie.android.renderer.ElmRendererDelegate
+import vivid.money.elmslie.samples.coroutines.timer.elm.*
+import vivid.money.elmslie.samples.coroutines.timer.elm.storeFactory
+
+internal class MainFragment :
+    Fragment(R.layout.fragment_main),
+    ElmRendererDelegate<Effect, State> {
+
+    companion object {
+        private const val ARG = "ARG"
+
+        fun newInstance(id: String): Fragment = MainFragment().apply {
+            arguments = Bundle().apply {
+                putString(ARG, id)
+            }
+        }
+    }
+
+    override val store by elmStore(
+        storeFactory = { savedStateHandle ->
+            storeFactory(
+                id = savedStateHandle[ARG]!!,
+            )
+        }
+    )
+
+    @Suppress("LeakingThis")
+    private val renderer =
+        ElmRenderer(
+            delegate = this,
+            screenLifecycle = lifecycle,
+        )
+
+    private lateinit var startButton: Button
+    private lateinit var stopButton: Button
+    private lateinit var currentValueText: TextView
+    private lateinit var screenIdText: TextView
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        startButton = view.findViewById(R.id.start)
+        stopButton = view.findViewById(R.id.stop)
+        currentValueText = view.findViewById(R.id.currentValue)
+        screenIdText = view.findViewById(R.id.screenId)
+
+        startButton.setOnClickListener { store.accept(Event.Start) }
+        stopButton.setOnClickListener { store.accept(Event.Stop) }
+    }
+
+    @SuppressLint("SetTextI18n")
+    override fun render(state: State) {
+        screenIdText.text = state.id
+        startButton.visibility = if (state.isStarted) GONE else VISIBLE
+        stopButton.visibility = if (state.isStarted) VISIBLE else GONE
+        currentValueText.text = "Seconds passed: ${state.secondsPassed}"
+    }
+
+    override fun handleEffect(effect: Effect) = when (effect) {
+        is Effect.Error -> Snackbar.make(
+            requireView().findViewById(R.id.content),
+            "Error!",
+            Snackbar.LENGTH_SHORT
+        ).show()
+    }
+}

--- a/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/StoreFactory.kt
+++ b/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/StoreFactory.kt
@@ -2,8 +2,10 @@ package vivid.money.elmslie.samples.coroutines.timer.elm
 
 import vivid.money.elmslie.coroutines.ElmStoreCompat
 
-internal fun storeFactory() = ElmStoreCompat(
-    initialState = State(),
+internal fun storeFactory(id: String) = ElmStoreCompat(
+    initialState = State(
+        id = id,
+    ),
     reducer = TimerReducer,
     actor = TimerActor,
     startEvent = Event.Init,

--- a/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/TimerActor.kt
+++ b/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/TimerActor.kt
@@ -16,7 +16,10 @@ internal object TimerActor : Actor<Command, Event> {
             is Command.Start ->
                 switcher
                     .switch { secondsFlow() }
-                    .mapEvents({ Event.OnTimeTick }, Event::OnTimeError)
+                    .mapEvents(
+                        eventMapper = { Event.OnTimeTick },
+                        errorMapper = { Event.OnTimeError(it) },
+                    )
             is Command.Stop -> switcher.cancel().mapEvents()
         }
 
@@ -24,7 +27,7 @@ internal object TimerActor : Actor<Command, Event> {
     private fun secondsFlow() = flow {
         repeat(10) {
             delay(1000)
-            emit(0)
+            emit(it)
         }
         error("Test error")
     }

--- a/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/TimerModels.kt
+++ b/elmslie-samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/elm/TimerModels.kt
@@ -1,6 +1,7 @@
 package vivid.money.elmslie.samples.coroutines.timer.elm
 
 internal data class State(
+    val id: String,
     val secondsPassed: Long = 0,
     val isStarted: Boolean = false
 )

--- a/elmslie-samples/coroutines-loader/src/main/res/layout/activity_main.xml
+++ b/elmslie-samples/coroutines-loader/src/main/res/layout/activity_main.xml
@@ -1,35 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/content"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/container"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:orientation="vertical">
-
-    <TextView
-        android:id="@+id/currentValue"
-        android:layout_width="match_parent"
-        android:layout_height="80dp"
-        android:gravity="center"
-        tools:text="Seconds passed: 10" />
-
-    <Button
-        android:id="@+id/start"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:text="@string/start" />
-
-    <Button
-        android:id="@+id/stop"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:text="@string/stop" />
-
-</LinearLayout>
+    android:layout_height="match_parent" />

--- a/elmslie-samples/coroutines-loader/src/main/res/layout/fragment_main.xml
+++ b/elmslie-samples/coroutines-loader/src/main/res/layout/fragment_main.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/content"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/screenId"
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        android:gravity="center"
+        tools:text="Screen id: " />
+
+    <TextView
+        android:id="@+id/currentValue"
+        android:layout_width="match_parent"
+        android:layout_height="80dp"
+        android:gravity="center"
+        tools:text="Seconds passed: 10" />
+
+    <Button
+        android:id="@+id/start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:text="@string/start" />
+
+    <Button
+        android:id="@+id/stop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:text="@string/stop" />
+
+</LinearLayout>

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -18,6 +18,7 @@ ext.deps = [
                 lifecycleKtx                : "androidx.lifecycle:lifecycle-runtime-ktx:2.5.0",
                 lifecycleViewmodel          : "androidx.lifecycle:lifecycle-viewmodel:2.5.0",
                 lifecycleViewModelSavedState: "androidx.lifecycle:lifecycle-viewmodel-savedstate:2.5.0",
+                fragmentKtx                 : "androidx.fragment:fragment-ktx:1.5.6",
                 material                    : "com.google.android.material:material:1.6.1",
                 multidex                    : "androidx.multidex:multidex:2.0.1",
                 paging                      : "androidx.paging:paging-runtime:3.2.0-alpha03",


### PR DESCRIPTION
When the flow inside `Switcher` throws exceptions sometimes it may cancel the whole scope and this error is not handling by `mapEvents` method. This leads to unexpected behavior and loose events for reducing. It can be reproduced in the sample app from this repository (coroutines-loader).

The exception which can be thrown and breaks the flow:
```
at vivid.money.elmslie.samples.coroutines.timer.elm.TimerActor$secondsFlow$1.invokeSuspend(TimerActor.kt:31)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
    	Suppressed: kotlinx.coroutines.JobCancellationException: ScopeCoroutine is cancelling; job=ScopeCoroutine{Cancelled}@96cd3f7
    	[CIRCULAR REFERENCE:java.lang.IllegalStateException: Test error]
```

Also, refresh one of the samples to use actual API + show the way of passing arguments to the store