### PR TITLE
Redesigned initialization elm store with renderer for fragment/activity

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -1,25 +1,127 @@
 package vivid.money.elmslie.android.renderer
 
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.annotation.MainThread
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State.RESUMED
 import androidx.lifecycle.Lifecycle.State.STARTED
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.flowWithLifecycle
-import androidx.lifecycle.whenCreated
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.withCreated
+import androidx.savedstate.SavedStateRegistryOwner
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import vivid.money.elmslie.android.util.fastLazy
 import vivid.money.elmslie.core.config.ElmslieConfig
+import vivid.money.elmslie.core.store.Store
 
-class ElmRenderer<Effect : Any, State : Any>(
+@Suppress("LongParameterList")
+@MainThread
+fun <
+        Event : Any,
+        Effect : Any,
+        State : Any,
+        > elmStoreWithRenderer(
+    lifecycleOwner: LifecycleOwner,
+    key: String = lifecycleOwner::class.java.canonicalName ?: lifecycleOwner::class.java.simpleName,
+    elmRenderer: ElmRendererDelegate<Effect, State>,
+    viewModelStoreOwner: () -> ViewModelStoreOwner,
+    savedStateRegistryOwner: () -> SavedStateRegistryOwner,
+    defaultArgs: () -> Bundle,
+    saveState: Bundle.(State) -> Unit = {},
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
+    val lazyStore = vivid.money.elmslie.android.elmStore(
+        storeFactory = storeFactory,
+        key = key,
+        viewModelStoreOwner = viewModelStoreOwner,
+        savedStateRegistryOwner = savedStateRegistryOwner,
+        saveState = saveState,
+        defaultArgs = defaultArgs,
+    )
+    with(lifecycleOwner) {
+        lifecycleScope.launch {
+            withCreated {
+                ElmRenderer(
+                    lazyStore.value,
+                    elmRenderer,
+                    lifecycle,
+                )
+            }
+        }
+    }
+    return lazyStore
+}
+
+@Suppress("LongParameterList")
+@MainThread
+fun <
+        Event : Any,
+        Effect : Any,
+        State : Any,
+        > Fragment.elmStoreWithRenderer(
+    key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
+    elmRenderer: ElmRendererDelegate<Effect, State>,
+    viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
+    savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
+    defaultArgs: () -> Bundle = { arguments ?: bundleOf() },
+    saveState: Bundle.(State) -> Unit = {},
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
+    return elmStoreWithRenderer(
+        lifecycleOwner = this,
+        key = key,
+        elmRenderer = elmRenderer,
+        viewModelStoreOwner = viewModelStoreOwner,
+        savedStateRegistryOwner = savedStateRegistryOwner,
+        defaultArgs = defaultArgs,
+        saveState = saveState,
+        storeFactory = storeFactory
+    )
+}
+
+@Suppress("LongParameterList")
+@MainThread
+fun <
+        Event : Any,
+        Effect : Any,
+        State : Any,
+        > ComponentActivity.elmStoreWithRenderer(
+    key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
+    elmRenderer: ElmRendererDelegate<Effect, State>,
+    viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
+    savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
+    defaultArgs: () -> Bundle = { intent?.extras ?: bundleOf() },
+    saveState: Bundle.(State) -> Unit = {},
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
+    return elmStoreWithRenderer(
+        lifecycleOwner = this,
+        key = key,
+        elmRenderer = elmRenderer,
+        viewModelStoreOwner = viewModelStoreOwner,
+        savedStateRegistryOwner = savedStateRegistryOwner,
+        defaultArgs = defaultArgs,
+        saveState = saveState,
+        storeFactory = storeFactory
+    )
+}
+
+internal class ElmRenderer<Effect : Any, State : Any>(
+    private val store: Store<*, Effect, State>,
     private val delegate: ElmRendererDelegate<Effect, State>,
     private val screenLifecycle: Lifecycle,
 ) {
 
-    private val store by fastLazy { delegate.store }
     private val logger = ElmslieConfig.logger
     private val ioDispatcher: CoroutineDispatcher = ElmslieConfig.ioDispatchers
     private val canRender
@@ -28,43 +130,35 @@ class ElmRenderer<Effect : Any, State : Any>(
     init {
         with(screenLifecycle) {
             coroutineScope.launch {
-                /**
-                 * [whenCreated] lambda is needed because we can't access to store before [Lifecycle.STARTED]
-                 * otherwise it crashes.
-                 */
-                whenCreated {
-                    store
-                        .effects
-                        .flowWithLifecycle(
-                            lifecycle = screenLifecycle,
-                            minActiveState = RESUMED,
-                        )
-                        .collect { effect -> catchEffectErrors { delegate.handleEffect(effect) } }
-                }
+                store
+                    .effects
+                    .flowWithLifecycle(
+                        lifecycle = screenLifecycle,
+                        minActiveState = RESUMED,
+                    )
+                    .collect { effect -> catchEffectErrors { delegate.handleEffect(effect) } }
             }
             coroutineScope.launch {
-                whenCreated {
-                    store
-                        .states
-                        .flowWithLifecycle(
-                            lifecycle = screenLifecycle,
-                            minActiveState = STARTED,
-                        )
-                        .map { state ->
-                            val list = mapListItems(state)
-                            state to list
-                        }
-                        .catch { logger.fatal("Crash while mapping state", it) }
-                        .flowOn(ioDispatcher)
-                        .collect { (state, listItems) ->
-                            catchStateErrors {
-                                if (canRender) {
-                                    delegate.renderList(state, listItems)
-                                    delegate.render(state)
-                                }
+                store
+                    .states
+                    .flowWithLifecycle(
+                        lifecycle = screenLifecycle,
+                        minActiveState = STARTED,
+                    )
+                    .map { state ->
+                        val list = mapListItems(state)
+                        state to list
+                    }
+                    .catch { logger.fatal("Crash while mapping state", it) }
+                    .flowOn(ioDispatcher)
+                    .collect { (state, listItems) ->
+                        catchStateErrors {
+                            if (canRender) {
+                                delegate.renderList(state, listItems)
+                                delegate.render(state)
                             }
                         }
-                }
+                    }
             }
         }
     }

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRendererDelegate.kt
@@ -1,11 +1,7 @@
 package vivid.money.elmslie.android.renderer
 
-import vivid.money.elmslie.core.store.Store
-
 @Suppress("OptionalUnit")
 interface ElmRendererDelegate<Effect : Any, State : Any> {
-    val store: Store<*, Effect, State>
-
     fun render(state: State)
     fun handleEffect(effect: Effect): Unit? = Unit
     fun mapList(state: State): List<Any> = emptyList()

--- a/samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainFragment.kt
+++ b/samples/coroutines-loader/src/main/java/vivid/money/elmslie/samples/coroutines/timer/MainFragment.kt
@@ -11,9 +11,8 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import vivid.money.elmslie.android.RetainedElmStore.Companion.StateBundleKey
-import vivid.money.elmslie.android.elmStore
-import vivid.money.elmslie.android.renderer.ElmRenderer
 import vivid.money.elmslie.android.renderer.ElmRendererDelegate
+import vivid.money.elmslie.android.renderer.elmStoreWithRenderer
 import vivid.money.elmslie.samples.coroutines.timer.elm.Effect
 import vivid.money.elmslie.samples.coroutines.timer.elm.Event
 import vivid.money.elmslie.samples.coroutines.timer.elm.State
@@ -29,23 +28,16 @@ internal class MainFragment : Fragment(R.layout.fragment_main), ElmRendererDeleg
             MainFragment().apply { arguments = bundleOf(ARG to id) }
     }
 
-    override val store by
-        elmStore(
-            storeFactory = {
-                storeFactory(
-                    id = get(ARG)!!,
-                    generatedId = get<Bundle>(StateBundleKey)?.getString(GENERATED_ID),
-                )
-            },
-            saveState = { state -> putString(GENERATED_ID, state.generatedId) },
-        )
-
-    @Suppress("LeakingThis")
-    private val renderer =
-        ElmRenderer(
-            delegate = this,
-            screenLifecycle = lifecycle,
-        )
+    private val store by elmStoreWithRenderer(
+        elmRenderer = this,
+        storeFactory = {
+            storeFactory(
+                id = get(ARG)!!,
+                generatedId = get<Bundle>(StateBundleKey)?.getString(GENERATED_ID),
+            )
+        },
+        saveState = { state -> putString(GENERATED_ID, state.generatedId) },
+    )
 
     private lateinit var startButton: Button
     private lateinit var stopButton: Button
@@ -78,10 +70,10 @@ internal class MainFragment : Fragment(R.layout.fragment_main), ElmRendererDeleg
         when (effect) {
             is Effect.Error ->
                 Snackbar.make(
-                        requireView().findViewById(R.id.content),
-                        "Error!",
-                        Snackbar.LENGTH_SHORT
-                    )
+                    requireView().findViewById(R.id.content),
+                    "Error!",
+                    Snackbar.LENGTH_SHORT
+                )
                     .show()
         }
 }


### PR DESCRIPTION
For now, the most dirty place is a creation connection between store and Fragment/Activity, for several reasons:
- we have to create unused property inside (render), and suppress 'this' reference
- the property forces users use the single store for all the UI and restricts to create multiple parallel ones. (except Compose)

This PR attempts to tackle this constraint, so users will be able to create implementations of the `ElmRendererDelegate`, with passing inside some parts of the UI.

Roughly, it can be done with the following way:
```
class MapDelegate(
  val map: MapBinding,
): ElmRendererDelegate {
  val mapStore by elmStoreWithRenderer()
  
  override fun render(state: MapState) {
    map.bind(state)
  }
}

```
These delegates are placed inside Fragment/Activity.

In addition, the initial phase simplify, we don't forget to create store property (like regular ViewModel) and it forces to add the `ElmRendererDelegate` interface

Also it resolves https://github.com/vivid-money/elmslie/issues/225 in case when consumers use androidx.lifecycle >= 2.6 version of the lib