### PR TITLE
Store listeners

### DIFF
--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/ElmStoreLazy.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/ElmStoreLazy.kt
@@ -23,14 +23,15 @@ fun <
     Event : Any,
     Effect : Any,
     State : Any,
+    Command : Any,
 > Fragment.elmStore(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { arguments ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> =
     vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -49,14 +50,15 @@ fun <
     Event : Any,
     Effect : Any,
     State : Any,
+    Command : Any,
 > ComponentActivity.elmStore(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { this.intent?.extras ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> =
     vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -71,14 +73,15 @@ internal fun <
     Event : Any,
     Effect : Any,
     State : Any,
+    Command : Any,
 > elmStore(
     key: String,
     viewModelStoreOwner: () -> ViewModelStoreOwner,
     savedStateRegistryOwner: () -> SavedStateRegistryOwner,
     defaultArgs: () -> Bundle,
     saveState: Bundle.(State) -> Unit,
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> =
     lazy(LazyThreadSafetyMode.NONE) {
         val factory =
             RetainedElmStoreFactory(
@@ -90,12 +93,12 @@ internal fun <
         val provider = ViewModelProvider(viewModelStoreOwner.invoke(), factory)
 
         @Suppress("UNCHECKED_CAST")
-        provider[key, RetainedElmStore::class.java].store as Store<Event, Effect, State>
+        provider[key, RetainedElmStore::class.java].store as Store<Event, Effect, State, Command>
     }
 
-class RetainedElmStore<Event : Any, Effect : Any, State : Any>(
+class RetainedElmStore<Event : Any, Effect : Any, State : Any, Command : Any>(
     savedStateHandle: SavedStateHandle,
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
     saveState: Bundle.(State) -> Unit,
 ) : ViewModel() {
 
@@ -117,10 +120,10 @@ class RetainedElmStore<Event : Any, Effect : Any, State : Any>(
     }
 }
 
-class RetainedElmStoreFactory<Event : Any, Effect : Any, State : Any>(
+class RetainedElmStoreFactory<Event : Any, Effect : Any, State : Any, Command : Any>(
     stateRegistryOwner: SavedStateRegistryOwner,
     defaultArgs: Bundle,
-    private val storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+    private val storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
     private val saveState: Bundle.(State) -> Unit,
 ) : AbstractSavedStateViewModelFactory(stateRegistryOwner, defaultArgs) {
 

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/ElmStoreLazy.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/ElmStoreLazy.kt
@@ -23,15 +23,14 @@ fun <
     Event : Any,
     Effect : Any,
     State : Any,
-    Command : Any,
 > Fragment.elmStore(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { arguments ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> =
     vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -50,15 +49,14 @@ fun <
     Event : Any,
     Effect : Any,
     State : Any,
-    Command : Any,
 > ComponentActivity.elmStore(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     viewModelStoreOwner: () -> ViewModelStoreOwner = { this },
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { this.intent?.extras ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> =
     vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -73,15 +71,14 @@ internal fun <
     Event : Any,
     Effect : Any,
     State : Any,
-    Command : Any,
 > elmStore(
     key: String,
     viewModelStoreOwner: () -> ViewModelStoreOwner,
     savedStateRegistryOwner: () -> SavedStateRegistryOwner,
     defaultArgs: () -> Bundle,
     saveState: Bundle.(State) -> Unit,
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> =
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> =
     lazy(LazyThreadSafetyMode.NONE) {
         val factory =
             RetainedElmStoreFactory(
@@ -93,12 +90,12 @@ internal fun <
         val provider = ViewModelProvider(viewModelStoreOwner.invoke(), factory)
 
         @Suppress("UNCHECKED_CAST")
-        provider[key, RetainedElmStore::class.java].store as Store<Event, Effect, State, Command>
+        provider[key, RetainedElmStore::class.java].store as Store<Event, Effect, State>
     }
 
-class RetainedElmStore<Event : Any, Effect : Any, State : Any, Command : Any>(
+class RetainedElmStore<Event : Any, Effect : Any, State : Any>(
     savedStateHandle: SavedStateHandle,
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
     saveState: Bundle.(State) -> Unit,
 ) : ViewModel() {
 
@@ -120,10 +117,10 @@ class RetainedElmStore<Event : Any, Effect : Any, State : Any, Command : Any>(
     }
 }
 
-class RetainedElmStoreFactory<Event : Any, Effect : Any, State : Any, Command : Any>(
+class RetainedElmStoreFactory<Event : Any, Effect : Any, State : Any>(
     stateRegistryOwner: SavedStateRegistryOwner,
     defaultArgs: Bundle,
-    private val storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+    private val storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
     private val saveState: Bundle.(State) -> Unit,
 ) : AbstractSavedStateViewModelFactory(stateRegistryOwner, defaultArgs) {
 

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -30,7 +30,6 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
-        Command : Any,
         > elmStoreWithRenderer(
     lifecycleOwner: LifecycleOwner,
     key: String = lifecycleOwner::class.java.canonicalName ?: lifecycleOwner::class.java.simpleName,
@@ -39,8 +38,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner,
     defaultArgs: () -> Bundle,
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
     val lazyStore = vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -69,7 +68,6 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
-        Command : Any,
         > Fragment.elmStoreWithRenderer(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     elmRenderer: ElmRendererDelegate<Effect, State>,
@@ -77,8 +75,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { arguments ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
     return elmStoreWithRenderer(
         lifecycleOwner = this,
         key = key,
@@ -97,7 +95,6 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
-        Command : Any,
         > ComponentActivity.elmStoreWithRenderer(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     elmRenderer: ElmRendererDelegate<Effect, State>,
@@ -105,8 +102,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { intent?.extras ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
-): Lazy<Store<Event, Effect, State, Command>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
+): Lazy<Store<Event, Effect, State>> {
     return elmStoreWithRenderer(
         lifecycleOwner = this,
         key = key,
@@ -120,7 +117,7 @@ fun <
 }
 
 internal class ElmRenderer<Effect : Any, State : Any>(
-    private val store: Store<*, Effect, State, *>,
+    private val store: Store<*, Effect, State>,
     private val delegate: ElmRendererDelegate<Effect, State>,
     private val screenLifecycle: Lifecycle,
 ) {

--- a/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
+++ b/elmslie-android/src/main/java/vivid/money/elmslie/android/renderer/ElmRenderer.kt
@@ -30,6 +30,7 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
+        Command : Any,
         > elmStoreWithRenderer(
     lifecycleOwner: LifecycleOwner,
     key: String = lifecycleOwner::class.java.canonicalName ?: lifecycleOwner::class.java.simpleName,
@@ -38,8 +39,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner,
     defaultArgs: () -> Bundle,
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> {
     val lazyStore = vivid.money.elmslie.android.elmStore(
         storeFactory = storeFactory,
         key = key,
@@ -68,6 +69,7 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
+        Command : Any,
         > Fragment.elmStoreWithRenderer(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     elmRenderer: ElmRendererDelegate<Effect, State>,
@@ -75,8 +77,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { arguments ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> {
     return elmStoreWithRenderer(
         lifecycleOwner = this,
         key = key,
@@ -85,7 +87,7 @@ fun <
         savedStateRegistryOwner = savedStateRegistryOwner,
         defaultArgs = defaultArgs,
         saveState = saveState,
-        storeFactory = storeFactory
+        storeFactory = storeFactory,
     )
 }
 
@@ -95,6 +97,7 @@ fun <
         Event : Any,
         Effect : Any,
         State : Any,
+        Command : Any,
         > ComponentActivity.elmStoreWithRenderer(
     key: String = this::class.java.canonicalName ?: this::class.java.simpleName,
     elmRenderer: ElmRendererDelegate<Effect, State>,
@@ -102,8 +105,8 @@ fun <
     savedStateRegistryOwner: () -> SavedStateRegistryOwner = { this },
     defaultArgs: () -> Bundle = { intent?.extras ?: bundleOf() },
     saveState: Bundle.(State) -> Unit = {},
-    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State>,
-): Lazy<Store<Event, Effect, State>> {
+    storeFactory: SavedStateHandle.() -> Store<Event, Effect, State, Command>,
+): Lazy<Store<Event, Effect, State, Command>> {
     return elmStoreWithRenderer(
         lifecycleOwner = this,
         key = key,
@@ -112,12 +115,12 @@ fun <
         savedStateRegistryOwner = savedStateRegistryOwner,
         defaultArgs = defaultArgs,
         saveState = saveState,
-        storeFactory = storeFactory
+        storeFactory = storeFactory,
     )
 }
 
 internal class ElmRenderer<Effect : Any, State : Any>(
-    private val store: Store<*, Effect, State>,
+    private val store: Store<*, Effect, State, *>,
     private val delegate: ElmRendererDelegate<Effect, State>,
     private val screenLifecycle: Lifecycle,
 ) {

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import vivid.money.elmslie.core.logger.ElmslieLogConfiguration
 import vivid.money.elmslie.core.logger.ElmslieLogger
 import vivid.money.elmslie.core.logger.strategy.IgnoreLog
+import vivid.money.elmslie.core.store.StoreListener
 
 object ElmslieConfig {
 
@@ -14,6 +15,8 @@ object ElmslieConfig {
 
     @Volatile private var _shouldStopOnProcessDeath: Boolean = true
 
+    @Volatile private var _globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>>? = null
+
     val logger: ElmslieLogger
         get() = _logger
 
@@ -22,6 +25,9 @@ object ElmslieConfig {
 
     val shouldStopOnProcessDeath: Boolean
         get() = _shouldStopOnProcessDeath
+
+    val globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>>?
+        get() = _globalStoreListeners
 
     init {
         logger { always(IgnoreLog) }
@@ -54,5 +60,9 @@ object ElmslieConfig {
 
     fun shouldStopOnProcessDeath(builder: () -> Boolean) {
         _shouldStopOnProcessDeath = builder()
+    }
+
+    fun globalStoreListeners(builder: () -> Set<StoreListener<Any, Any, Any, Any>>) {
+        _globalStoreListeners = builder()
     }
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/config/ElmslieConfig.kt
@@ -15,7 +15,7 @@ object ElmslieConfig {
 
     @Volatile private var _shouldStopOnProcessDeath: Boolean = true
 
-    @Volatile private var _globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>>? = null
+    @Volatile private var _globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>> = emptySet()
 
     val logger: ElmslieLogger
         get() = _logger
@@ -26,7 +26,7 @@ object ElmslieConfig {
     val shouldStopOnProcessDeath: Boolean
         get() = _shouldStopOnProcessDeath
 
-    val globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>>?
+    val globalStoreListeners: Set<StoreListener<Any, Any, Any, Any>>
         get() = _globalStoreListeners
 
     init {

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectCachingElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectCachingElmStore.kt
@@ -18,9 +18,9 @@ import java.util.concurrent.LinkedBlockingQueue
  * ```
  */
 // TODO Should be moved to android artifact?
-class EffectCachingElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
-    private val elmStore: Store<Event, Effect, State, Command>,
-) : Store<Event, Effect, State, Command> by elmStore {
+class EffectCachingElmStore<Event : Any, State : Any, Effect : Any>(
+    private val elmStore: Store<Event, Effect, State>,
+) : Store<Event, Effect, State> by elmStore {
 
     private val effectsCache = LinkedBlockingQueue<Effect>()
     private val effectsFlow = MutableSharedFlow<Effect>()

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectCachingElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/EffectCachingElmStore.kt
@@ -1,12 +1,12 @@
 package vivid.money.elmslie.core.store
 
-import java.util.concurrent.LinkedBlockingQueue
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import vivid.money.elmslie.core.ElmScope
+import java.util.concurrent.LinkedBlockingQueue
 
 /**
  * Caches effects until there is at least one collector.
@@ -18,9 +18,9 @@ import vivid.money.elmslie.core.ElmScope
  * ```
  */
 // TODO Should be moved to android artifact?
-class EffectCachingElmStore<Event : Any, State : Any, Effect : Any>(
-    private val elmStore: Store<Event, Effect, State>,
-) : Store<Event, Effect, State> by elmStore {
+class EffectCachingElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
+    private val elmStore: Store<Event, Effect, State, Command>,
+) : Store<Event, Effect, State, Command> by elmStore {
 
     private val effectsCache = LinkedBlockingQueue<Effect>()
     private val effectsFlow = MutableSharedFlow<Effect>()

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -24,7 +24,7 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
     private val actor: Actor<Command, out Event>,
     storeListeners: Set<StoreListener<Event, State, Effect, Command>>? = null,
     override val startEvent: Event? = null,
-) : Store<Event, Effect, State, Command> {
+) : Store<Event, Effect, State> {
 
     private val logger = ElmslieConfig.logger
     private val eventMutex = Mutex()
@@ -47,21 +47,13 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
 
     override fun accept(event: Event) = dispatchEvent(event)
 
-    override fun start(): Store<Event, Effect, State, Command> {
+    override fun start(): Store<Event, Effect, State> {
         startEvent?.let(::accept)
         return this
     }
 
     override fun stop() {
         scope.cancel()
-    }
-
-    override fun deattachListener(storeListener: StoreListener<Event, State, Effect, Command>) {
-        storeListeners.add(storeListener)
-    }
-
-    override fun attachListener(storeListener: StoreListener<Event, State, Effect, Command>) {
-        storeListeners.remove(storeListener)
     }
 
     private fun dispatchEvent(event: Event) {
@@ -111,5 +103,5 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
     }
 }
 
-fun <Event : Any, State : Any, Effect : Any, Command: Any> Store<Event, State, Effect, Command>.toCachedStore() =
+fun <Event : Any, State : Any, Effect : Any> Store<Event, State, Effect>.toCachedStore() =
     EffectCachingElmStore(this)

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/ElmStore.kt
@@ -35,7 +35,7 @@ class ElmStore<Event : Any, State : Any, Effect : Any, Command : Any>(
 
     private val storeListeners: MutableSet<StoreListener<in Event, in State, in Effect, in Command>> =
         mutableSetOf<StoreListener<in Event, in State, in Effect, in Command>>().apply {
-            ElmslieConfig.globalStoreListeners?.forEach(::add)
+            ElmslieConfig.globalStoreListeners.forEach(::add)
             storeListeners?.forEach(::add)
         }
 

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
-interface Store<Event, Effect, State> {
+interface Store<Event : Any, Effect: Any, State: Any, Command: Any> {
 
     /** Event that will be emitted upon store start. */
     val startEvent: Event?
@@ -36,7 +36,7 @@ interface Store<Event, Effect, State> {
     /**
      * Starts the operations inside the store.
      */
-    fun start(): Store<Event, Effect, State>
+    fun start(): Store<Event, Effect, State, Command>
 
     /**
      * Stops all operations inside the store and cancels coroutines scope.
@@ -46,4 +46,16 @@ interface Store<Event, Effect, State> {
 
     /** Sends a new [Event] for the store. */
     fun accept(event: Event)
+
+    /**
+     * Attach store listener to consume all that happend inside store.
+     * Not thread safe.
+     */
+    fun attachListener(storeListener: StoreListener<Event, State, Effect, Command>)
+
+    /**
+     * Deattach store listener.
+     * Not thread safe.
+     */
+    fun deattachListener(storeListener: StoreListener<Event, State, Effect, Command>)
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/Store.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
-interface Store<Event : Any, Effect: Any, State: Any, Command: Any> {
+interface Store<Event : Any, Effect: Any, State: Any> {
 
     /** Event that will be emitted upon store start. */
     val startEvent: Event?
@@ -36,7 +36,7 @@ interface Store<Event : Any, Effect: Any, State: Any, Command: Any> {
     /**
      * Starts the operations inside the store.
      */
-    fun start(): Store<Event, Effect, State, Command>
+    fun start(): Store<Event, Effect, State>
 
     /**
      * Stops all operations inside the store and cancels coroutines scope.
@@ -46,16 +46,4 @@ interface Store<Event : Any, Effect: Any, State: Any, Command: Any> {
 
     /** Sends a new [Event] for the store. */
     fun accept(event: Event)
-
-    /**
-     * Attach store listener to consume all that happend inside store.
-     * Not thread safe.
-     */
-    fun attachListener(storeListener: StoreListener<Event, State, Effect, Command>)
-
-    /**
-     * Deattach store listener.
-     * Not thread safe.
-     */
-    fun deattachListener(storeListener: StoreListener<Event, State, Effect, Command>)
 }

--- a/elmslie-core/src/main/java/vivid/money/elmslie/core/store/StoreListener.kt
+++ b/elmslie-core/src/main/java/vivid/money/elmslie/core/store/StoreListener.kt
@@ -1,0 +1,12 @@
+package vivid.money.elmslie.core.store
+
+interface StoreListener<Event : Any, State : Any, Effect : Any, Command : Any> {
+
+    fun onEvent(event: Event) {}
+    fun onEffect(effect: Effect) {}
+    fun onCommand(command: Command) {}
+    fun onStateChanged(newState: State, oldState: State, eventCause: Event) {}
+
+    fun onReducerError(throwable: Throwable, event: Event) {}
+    fun onCommandError(throwable: Throwable, command: Command) {}
+}


### PR DESCRIPTION
You can add listeners on 3 lvls:
- global listeners in Elmslie config
- in-store constructor
- in runtime with attach/deatachListener store methods (not thread safe)

Closes https://github.com/vivid-money/elmslie/issues/207