### PR TITLE
ci: fix Kotlin/Native caching across the publishing workflows

### DIFF
--- a/.github/actions/cache-kotlin-native/action.yml
+++ b/.github/actions/cache-kotlin-native/action.yml
@@ -1,0 +1,35 @@
+name: Cache Kotlin/Native
+description: Restores the Kotlin/Native toolchain from the cache, and saves it back when requested.
+
+inputs:
+  save:
+    description: Save the toolchain back to the cache once the job succeeds.
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Kotlin version
+      id: kotlin
+      shell: bash
+      run: |
+        VERSION=$(./.github/sh/parse_version_catalog.sh kotlin)
+        echo "version=$VERSION" >>"$GITHUB_OUTPUT"
+
+    - name: Cache Kotlin/Native
+      if: inputs.save == 'true'
+      uses: actions/cache@v6
+      with:
+        path: |
+          ~/.konan
+          !~/.konan/dependencies/cache
+        key: konan-${{ runner.os }}-${{ steps.kotlin.outputs.version }}
+
+    - name: Restore Kotlin/Native
+      if: inputs.save != 'true'
+      uses: actions/cache/restore@v6
+      with:
+        path: |
+          ~/.konan
+          !~/.konan/dependencies/cache
+        key: konan-${{ runner.os }}-${{ steps.kotlin.outputs.version }}

--- a/.github/sh/parse_version_catalog.sh
+++ b/.github/sh/parse_version_catalog.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+PROPERTY="$1"
+FILE="gradle/libs.versions.toml"
+VERSION=$(sed -En "s/^$PROPERTY = \"([^\"]+)\"$/\1/p" "$FILE")
+
+if [[ -z $VERSION ]]; then
+  echo "::error ::Version '$PROPERTY' not found in $FILE"
+  exit 1
+fi
+
+echo "$VERSION"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -28,20 +28,9 @@ jobs:
           java-version: 21
 
       - name: Cache Kotlin/Native
-        if: github.ref == 'refs/heads/main'
-        uses: actions/cache@v6
+        uses: ./.github/actions/cache-kotlin-native
         with:
-          path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: konan-${{ runner.os }}-
-
-      - name: Restore Kotlin/Native
-        if: github.ref != 'refs/heads/main'
-        uses: actions/cache/restore@v6
-        with:
-          path: ~/.konan
-          key: konan-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
-          restore-keys: konan-${{ runner.os }}-
+          save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/publish-to-maven.yml
+++ b/.github/workflows/publish-to-maven.yml
@@ -30,6 +30,11 @@ jobs:
           distribution: zulu
           java-version: 21
 
+      - name: Cache Kotlin/Native
+        uses: ./.github/actions/cache-kotlin-native
+        with:
+          save: 'true'
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
           distribution: zulu
           java-version: 21
 
+      - name: Restore Kotlin/Native
+        uses: ./.github/actions/cache-kotlin-native
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         with:


### PR DESCRIPTION
## Context

Checked the CI logs after #280. The `konan-Linux-<hash>` misses in the code quality logs were a **cold start**, not a broken cache — the step was introduced by that PR and the first save landed in run [34493603417](https://github.com/vivid-money/elmslie/actions/runs/34493603417):

```
Post Cache Kotlin/Native  Cache saved with key: konan-Linux-1a0550e8… (694.83 MiB)
```

The mechanism works. Three real problems remained.

## 1. `release` and `publish-to-maven` never cached `~/.konan`

Release run [34494625266](https://github.com/vivid-money/elmslie/actions/runs/34494625266) restored 1298MB of Gradle state and still downloaded the entire native toolchain:

```
llvm-21-x86_64-linux-essentials-116.tar.gz
aarch64-unknown-linux-gnu-gcc-8.3.0-…, x86_64-unknown-linux-gnu-gcc-8.3.0-…
libffi, qemu-aarch64-static, lldb-4-linux, msys2-mingw-w64
```

`~/.konan` sits outside the Gradle User Home, so `setup-gradle` can never cover it.

Both workflows now use the cache. `release` restores only — the code quality workflow on `main` is the writer for Linux. `publish-to-maven` runs on `macos-latest`, where no workflow ever wrote an entry, so it restores *and* saves.

## 2. The key invalidated on every dependency bump

`hashFiles('gradle/libs.versions.toml')` changed whenever any entry in the catalog moved, discarding a 700MB entry that only depends on `kotlin = "2.4.20"`. Now keyed on the Kotlin version alone, read by `.github/sh/parse_version_catalog.sh` (same `sed -En` shape as the existing `parse_gradle_property.sh`, and it fails loudly rather than silently yielding an empty key).

`restore-keys` is dropped deliberately. It made a Kotlin upgrade restore the old bundle, download the new one alongside it, and save both — so the entry accreted stale `kotlin-native-prebuilt-*` directories and grew ~700MB per upgrade. The cost is one cold download per Kotlin upgrade; the benefit is a bounded entry.

## 3. Cached archives alongside their extracted contents

`~/.konan/dependencies/cache` holds the downloaded `.tar.gz` files next to the trees already extracted from them. Excluded from the cached paths.

## Note on sharing the Gradle cache scope

I said the `check` and `validate` jobs were writing duplicate ~1GB dependency caches and suggested unifying their scope. **That was wrong, and there is nothing to fix.** Cross-job restore already works — `validate` hit `check`'s entry through the default restore keys:

```
Cache hit for restore-key: gradle-home-v2|Linux-X64|check[f8f9900f…]-9b8cc4c…
Cache hit for: gradle-dependencies-v2-d44c0db9004b99a4ee7c41a54aa43247
```

The second `gradle-dependencies-v2-166b2c8…` (952MiB) entry is a *superset* of the first (863MiB): `publishToMavenLocal` resolves the publishing and signing plugins that `build` does not. The enhanced provider keys those entries by content, not by job, so the divergence is inherent to the two workflows running different task sets, and it converges once both entry sets exist. `gradle-home-cache-strict-match` is already `false`.

Quota is still worth watching — 3.26GB of 10GB after two runs, with LRU eviction. Having `release` and `publish-to-maven` touch the konan entry helps keep it warm rather than letting it age out as the coldest entry.

## Verification

YAML parses for all four files; the parser was exercised on both the hit and miss paths. The save side of the Linux entry only runs on `main`, so it is exercised when this merges, not by CI on this branch.
